### PR TITLE
Feature/dashboard color picker v24.11.0

### DIFF
--- a/client/app/assets/less/inc/tile.less
+++ b/client/app/assets/less/inc/tile.less
@@ -1,5 +1,5 @@
 .tile {
-    background-color: #fff;
+    background-color: var(--dashboard-background-color, #ffffff);
     margin-bottom: @grid-gutter-width;
     position: relative;
     border-radius: 3px;
@@ -16,6 +16,7 @@
 .tiled {
     border-radius: 3px;
     box-shadow: fade(@redash-gray, 15%) 0px 4px 9px -3px;
+    background-color: var(--dashboard-background-color, #ffffff);
 }
 
 .t-header {
@@ -25,6 +26,7 @@
 
     &:not(.th-alt) {
         padding: 20px 23px;
+        background-color: var(--dashboard-background-color, #ffffff);
         
         .th-title {
             font-size: 17px;

--- a/client/app/assets/less/inc/tile.less
+++ b/client/app/assets/less/inc/tile.less
@@ -1,107 +1,106 @@
 .tile {
-    background-color: var(--dashboard-background-color, #ffffff);
-    margin-bottom: @grid-gutter-width;
-    position: relative;
-    border-radius: 3px;
-    box-shadow: fade(@redash-gray, 15%) 0px 4px 9px -3px;
-    
-    &[class*="bg-"] {
-        color: #fff;
-    }
-    
-    @media (max-width: @screen-sm-min) {
-        margin-bottom: @grid-gutter-width/2;
-    }
+  background-color: var(--dashboard-background-color, #ffffff);
+  margin-bottom: @grid-gutter-width;
+  position: relative;
+  border-radius: 3px;
+  box-shadow: fade(@redash-gray, 15%) 0px 4px 9px -3px;
+
+  &[class*="bg-"] {
+    color: #fff;
+  }
+
+  @media (max-width: @screen-sm-min) {
+    margin-bottom: @grid-gutter-width / 2;
+  }
 }
 .tiled {
-    border-radius: 3px;
-    box-shadow: fade(@redash-gray, 15%) 0px 4px 9px -3px;
-    background-color: var(--dashboard-background-color, #ffffff);
+  border-radius: 3px;
+  box-shadow: fade(@redash-gray, 15%) 0px 4px 9px -3px;
+  background-color: var(--dashboard-background-color, #ffffff);
 }
 
 .t-header {
+  .th-title {
+    line-height: 100%;
+  }
+
+  &:not(.th-alt) {
+    padding: 20px 23px;
+    background-color: var(--dashboard-background-color, #ffffff);
+
     .th-title {
-        line-height: 100%;
-    }
+      font-size: 17px;
+      font-weight: 400;
+      color: #333;
 
-    &:not(.th-alt) {
-        padding: 20px 23px;
-        background-color: var(--dashboard-background-color, #ffffff);
-        
-        .th-title {
-            font-size: 17px;
-            font-weight: 400;
-            color: #333;
-            
-            small {
-                font-size: 12px;
-                color: #9C9C9C;
-                margin-top: 3px;
-                display: block;
-            }
-        }
-    }
-
-    &.widget {
-        padding: 5px;
-    }
-
-
-    &.th-alt {
-        padding: 10px 15px 9px;
-        
-        .actions {
-            & > a {
-                color: #fff;
-            }
-        }
-        
-        &[class*="bg-"] {
-            .th-title {
-                color: #fff;
-            }
-        }
-    }
-    
-    .actions {
-        right: 0;
-        top: 0; 
-        
-        & > a {
-            font-size: 24px;
-            line-height: 100%;
-            padding: 4px 10px 3px;
-            display: block;
-        }
-        
-        & > a:hover,
-        &.open > a {
-            background-color: rgba(0, 0, 0, 0.1);
-        }
-    }
-}
-
-.t-header:not(.th-alt) {
-    padding: 15px;
-  
-    ul {
-      margin-bottom: 0;
-      line-height: 2.2;
+      small {
+        font-size: 12px;
+        color: #9c9c9c;
+        margin-top: 3px;
+        display: block;
+      }
     }
   }
 
+  &.widget {
+    padding: 5px;
+  }
+
+  &.th-alt {
+    padding: 10px 15px 9px;
+
+    .actions {
+      & > a {
+        color: #fff;
+      }
+    }
+
+    &[class*="bg-"] {
+      .th-title {
+        color: #fff;
+      }
+    }
+  }
+
+  .actions {
+    right: 0;
+    top: 0;
+
+    & > a {
+      font-size: 24px;
+      line-height: 100%;
+      padding: 4px 10px 3px;
+      display: block;
+    }
+
+    & > a:hover,
+    &.open > a {
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+  }
+}
+
+.t-header:not(.th-alt) {
+  padding: 15px;
+
+  ul {
+    margin-bottom: 0;
+    line-height: 2.2;
+  }
+}
+
 .tb-padding {
-    padding: 20px 23px 30px;
+  padding: 20px 23px 30px;
 }
 
 .t-body a.actions {
-    font-size: 24px;
-    line-height: 100%;
-    padding: 4px 10px 3px;
-    display: block;
+  font-size: 24px;
+  line-height: 100%;
+  padding: 4px 10px 3px;
+  display: block;
 }
 
 .t-body a.actions:hover,
 .t-body a.actions.open > a {
-    background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.1);
 }

--- a/client/app/components/ApplicationArea/Router.jsx
+++ b/client/app/components/ApplicationArea/Router.jsx
@@ -84,7 +84,7 @@ export default function Router({ routes, onRouteChange }) {
               setCurrentRoute({ ...route, key: generateRouteKey() });
             }
           })
-          .catch(error => {
+          .catch((error) => {
             if (!isAbandoned && currentPathRef.current === pathname) {
               setCurrentRoute({
                 render: currentRoute => <ErrorMessage {...currentRoute.routeParams} />,

--- a/client/app/components/CreateSourceDialog.jsx
+++ b/client/app/components/CreateSourceDialog.jsx
@@ -67,7 +67,7 @@ class CreateSourceDialog extends React.Component {
           successCallback("Saved.");
           this.props.dialog.close({ success: true, data });
         })
-        .catch(error => {
+        .catch((error) => {
           this.setState({ savingSource: false, currentStep: StepEnum.CONFIGURE_IT });
           errorCallback(get(error, "response.data.message", "Failed saving."));
         });

--- a/client/app/components/ParameterValueInput.less
+++ b/client/app/components/ParameterValueInput.less
@@ -6,10 +6,13 @@
   display: inline-block;
   position: relative;
   width: 100%;
+  background: inherit;
 
   .@{ant-prefix}-input,
-  .@{ant-prefix}-input-number {
-    min-width: 100% !important;
+  .@{ant-prefix}-input-number,
+  .@{ant-prefix}-select-selector,
+  .@{ant-prefix}-picker {
+    background: inherit;
   }
 
   .@{ant-prefix}-select {

--- a/client/app/components/Parameters.less
+++ b/client/app/components/Parameters.less
@@ -2,7 +2,7 @@
 
 .parameter-block {
   display: inline-block;
-  background: white;
+  background: inherit;
   padding: 0 12px 6px 0;
   vertical-align: top;
   z-index: 1;
@@ -49,6 +49,7 @@
 
 .parameter-container {
   position: relative;
+  background: inherit;
 
   &.sortable-container {
     padding: 0 4px 4px 0;
@@ -66,7 +67,7 @@
       z-index: 2;
       transition: opacity 150ms ease-out;
       box-shadow: 0 4px 9px -3px rgba(102, 136, 153, 0.15);
-      background-color: #ffffff;
+      background: inherit;
       padding: 4px;
       padding-left: 16px;
       opacity: 0;

--- a/client/app/components/SelectItemsDialog.jsx
+++ b/client/app/components/SelectItemsDialog.jsx
@@ -87,7 +87,7 @@ function SelectItemsDialog({
   );
 
   const save = useCallback(() => {
-    dialog.close(selectedItems).catch(error => {
+    dialog.close(selectedItems).catch((error) => {
       if (error) {
         notification.error("Failed to save some of selected items.");
       }

--- a/client/app/components/dashboards/DashboardGrid.jsx
+++ b/client/app/components/dashboards/DashboardGrid.jsx
@@ -37,15 +37,15 @@ const DashboardWidget = React.memo(
   function DashboardWidget({
     widget,
     dashboard,
-    onLoadWidget,
-    onRefreshWidget,
-    onRemoveWidget,
-    onParameterMappingsChange,
+    filters,
     isEditing,
     canEdit,
     isPublic,
     isLoading,
-    filters,
+    onLoadWidget,
+    onRefreshWidget,
+    onRemoveWidget,
+    onParameterMappingsChange,
   }) {
     const { type } = widget;
     const onLoad = () => onLoadWidget(widget);
@@ -66,6 +66,7 @@ const DashboardWidget = React.memo(
           onRefresh={onRefresh}
           onDelete={onDelete}
           onParameterMappingsChange={onParameterMappingsChange}
+          backgroundColor={dashboard.options?.backgroundColor}
         />
       );
     }
@@ -152,11 +153,25 @@ class DashboardGrid extends React.Component {
     setTimeout(() => {
       this.setState({ disableAnimations: false });
     }, 50);
+
+    // Set background color CSS variable
+    const wrapper = document.querySelector('.dashboard-wrapper');
+    if (wrapper) {
+      wrapper.style.setProperty('--dashboard-background-color', this.props.dashboard.options?.backgroundColor || '#ffffff');
+    }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     // update, in case widgets added or removed
     this.autoHeightCtrl.update(this.props.widgets);
+
+    // Update background color if changed
+    if (prevProps.dashboard.options?.backgroundColor !== this.props.dashboard.options?.backgroundColor) {
+      const wrapper = document.querySelector('.dashboard-wrapper');
+      if (wrapper) {
+        wrapper.style.setProperty('--dashboard-background-color', this.props.dashboard.options?.backgroundColor || '#ffffff');
+      }
+    }
   }
 
   componentWillUnmount() {
@@ -168,7 +183,9 @@ class DashboardGrid extends React.Component {
     // fixes test dashboard_spec['shows widgets with full width']
     // TODO: open react-grid-layout issue
     if (layouts[MULTI]) {
-      this.setState({ layouts });
+      // Create a deep copy of layouts to prevent mutation
+      const newLayouts = JSON.parse(JSON.stringify(layouts));
+      this.setState({ layouts: newLayouts });
     }
 
     // workaround for https://github.com/STRML/react-grid-layout/issues/889
@@ -181,12 +198,24 @@ class DashboardGrid extends React.Component {
       return;
     }
 
+    // Convert layout to object format expected by the model
     const normalized = chain(layouts[MULTI])
       .keyBy("i")
-      .mapValues(this.normalizeTo)
+      .mapValues(item => ({
+        col: item.x,
+        row: item.y,
+        sizeX: item.w,
+        sizeY: item.h,
+        autoHeight: this.autoHeightCtrl.exists(item.i),
+      }))
       .value();
 
-    this.props.onLayoutChange(normalized);
+    // Ensure we're passing an object, not an array
+    if (normalized && typeof normalized === 'object' && !Array.isArray(normalized)) {
+      // Create an immutable copy before passing to parent
+      const immutableLayout = Object.freeze({ ...normalized });
+      this.props.onLayoutChange(immutableLayout);
+    }
   };
 
   onBreakpointChange = mode => {
@@ -216,14 +245,6 @@ class DashboardGrid extends React.Component {
 
     this.autoHeightCtrl.resume();
   };
-
-  normalizeTo = layout => ({
-    col: layout.x,
-    row: layout.y,
-    sizeX: layout.w,
-    sizeY: layout.h,
-    autoHeight: this.autoHeightCtrl.exists(layout.i),
-  });
 
   render() {
     const {

--- a/client/app/components/dashboards/DashboardGrid.jsx
+++ b/client/app/components/dashboards/DashboardGrid.jsx
@@ -155,9 +155,12 @@ class DashboardGrid extends React.Component {
     }, 50);
 
     // Set background color CSS variable
-    const wrapper = document.querySelector('.dashboard-wrapper');
+    const wrapper = document.querySelector(".dashboard-wrapper");
     if (wrapper) {
-      wrapper.style.setProperty('--dashboard-background-color', this.props.dashboard.options?.backgroundColor || '#ffffff');
+      wrapper.style.setProperty(
+        "--dashboard-background-color",
+        this.props.dashboard.options?.backgroundColor || "#ffffff"
+      );
     }
   }
 
@@ -167,9 +170,12 @@ class DashboardGrid extends React.Component {
 
     // Update background color if changed
     if (prevProps.dashboard.options?.backgroundColor !== this.props.dashboard.options?.backgroundColor) {
-      const wrapper = document.querySelector('.dashboard-wrapper');
+      const wrapper = document.querySelector(".dashboard-wrapper");
       if (wrapper) {
-        wrapper.style.setProperty('--dashboard-background-color', this.props.dashboard.options?.backgroundColor || '#ffffff');
+        wrapper.style.setProperty(
+          "--dashboard-background-color",
+          this.props.dashboard.options?.backgroundColor || "#ffffff"
+        );
       }
     }
   }
@@ -211,7 +217,7 @@ class DashboardGrid extends React.Component {
       .value();
 
     // Ensure we're passing an object, not an array
-    if (normalized && typeof normalized === 'object' && !Array.isArray(normalized)) {
+    if (normalized && typeof normalized === "object" && !Array.isArray(normalized)) {
       // Create an immutable copy before passing to parent
       const immutableLayout = Object.freeze({ ...normalized });
       this.props.onLayoutChange(immutableLayout);

--- a/client/app/components/dashboards/Widget.jsx
+++ b/client/app/components/dashboards/Widget.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { VisualizationWidget, TextboxWidget, RestrictedWidget } from "@/components/dashboards/dashboard-widget";
+import { WidgetTypeEnum } from "./WidgetTypeEnum";
+
+function Widget({
+  widget,
+  dashboard,
+  filters,
+  isEditing,
+  isPublic,
+  onLoadWidget,
+  onRefreshWidget,
+  onRemoveWidget,
+  onParameterMappingsChange,
+  backgroundColor,
+}) {
+  const { type } = widget;
+  const onLoad = () => onLoadWidget(widget);
+  const onRefresh = () => onRefreshWidget(widget);
+  const onDelete = () => onRemoveWidget(widget.id);
+
+  if (type === WidgetTypeEnum.VISUALIZATION) {
+    return (
+      <VisualizationWidget
+        widget={widget}
+        dashboard={dashboard}
+        filters={filters}
+        isEditing={isEditing}
+        canEdit={dashboard.canEdit()}
+        isPublic={isPublic}
+        isLoading={widget.loading}
+        onLoad={onLoad}
+        onRefresh={onRefresh}
+        onDelete={onDelete}
+        onParameterMappingsChange={onParameterMappingsChange}
+        backgroundColor={backgroundColor}
+      />
+    );
+  }
+  if (type === WidgetTypeEnum.TEXTBOX) {
+    return (
+      <TextboxWidget
+        widget={widget}
+        canEdit={dashboard.canEdit()}
+        isPublic={isPublic}
+        onDelete={onDelete}
+      />
+    );
+  }
+  return <RestrictedWidget widget={widget} />;
+}
+
+Widget.propTypes = {
+  widget: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  filters: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  isEditing: PropTypes.bool,
+  isPublic: PropTypes.bool,
+  onLoadWidget: PropTypes.func,
+  onRefreshWidget: PropTypes.func,
+  onRemoveWidget: PropTypes.func,
+  onParameterMappingsChange: PropTypes.func,
+  backgroundColor: PropTypes.string,
+};
+
+Widget.defaultProps = {
+  filters: {},
+  isEditing: false,
+  isPublic: false,
+  onLoadWidget: () => {},
+  onRefreshWidget: () => {},
+  onRemoveWidget: () => {},
+  onParameterMappingsChange: () => {},
+  backgroundColor: null,
+};
+
+export default Widget; 

--- a/client/app/components/dashboards/Widget.jsx
+++ b/client/app/components/dashboards/Widget.jsx
@@ -39,14 +39,7 @@ function Widget({
     );
   }
   if (type === WidgetTypeEnum.TEXTBOX) {
-    return (
-      <TextboxWidget
-        widget={widget}
-        canEdit={dashboard.canEdit()}
-        isPublic={isPublic}
-        onDelete={onDelete}
-      />
-    );
+    return <TextboxWidget widget={widget} canEdit={dashboard.canEdit()} isPublic={isPublic} onDelete={onDelete} />;
   }
   return <RestrictedWidget widget={widget} />;
 }
@@ -75,4 +68,4 @@ Widget.defaultProps = {
   backgroundColor: null,
 };
 
-export default Widget; 
+export default Widget;

--- a/client/app/components/dashboards/dashboard-grid.less
+++ b/client/app/components/dashboards/dashboard-grid.less
@@ -1,6 +1,7 @@
 .dashboard-wrapper {
   flex-grow: 1;
   margin-bottom: 70px;
+  background-color: var(--dashboard-background-color, #ffffff);
 
   .layout {
     margin: -15px -15px 0;
@@ -123,7 +124,7 @@
       right: 10px;
       bottom: 15px;
       height: auto;
-      overflow: visible;
+      overflow: hidden;
       padding: 0;
     }
   }

--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -4,77 +4,21 @@ import { compact, isEmpty, invoke, map } from "lodash";
 import { markdown } from "markdown";
 import cx from "classnames";
 import Menu from "antd/lib/menu";
+import notification from "antd/lib/notification";
 import HtmlContent from "@redash/viz/lib/components/HtmlContent";
-import { currentUser } from "@/services/auth";
-import recordEvent from "@/services/recordEvent";
 import { formatDateTime } from "@/lib/utils";
 import Link from "@/components/Link";
 import Parameters from "@/components/Parameters";
 import TimeAgo from "@/components/TimeAgo";
 import Timer from "@/components/Timer";
 import { Moment } from "@/components/proptypes";
-import QueryLink from "@/components/QueryLink";
 import { FiltersType } from "@/components/Filters";
 import PlainButton from "@/components/PlainButton";
-import ExpandedWidgetDialog from "@/components/dashboards/ExpandedWidgetDialog";
 import EditParameterMappingsDialog from "@/components/dashboards/EditParameterMappingsDialog";
 import VisualizationRenderer from "@/components/visualizations/VisualizationRenderer";
+import { registeredVisualizations } from "@redash/viz/lib";
 
 import Widget from "./Widget";
-
-function visualizationWidgetMenuOptions({ widget, canEditDashboard, onParametersEdit }) {
-  const canViewQuery = currentUser.hasPermission("view_query");
-  const canEditParameters = canEditDashboard && !isEmpty(invoke(widget, "query.getParametersDefs"));
-  const widgetQueryResult = widget.getQueryResult();
-  const isQueryResultEmpty = !widgetQueryResult || !widgetQueryResult.isEmpty || widgetQueryResult.isEmpty();
-  const parts = window.location.pathname.split('/').reverse()
-  var apiKey = null;
-  if (parts.length > 3 && parts[2] === 'public' && parts[0].length === 40) {
-    apiKey = parts[0];
-  }
-  const downloadLink = fileType => widgetQueryResult.getLink(widget.getQuery().id, fileType, apiKey);
-  const downloadName = fileType => widgetQueryResult.getName(widget.getQuery().name, fileType);
-  return compact([
-    <Menu.Item key="download_csv" disabled={isQueryResultEmpty}>
-      {!isQueryResultEmpty ? (
-        <Link href={downloadLink("csv")} download={downloadName("csv")} target="_self">
-          Download as CSV File
-        </Link>
-      ) : (
-        "Download as CSV File"
-      )}
-    </Menu.Item>,
-    <Menu.Item key="download_tsv" disabled={isQueryResultEmpty}>
-      {!isQueryResultEmpty ? (
-        <Link href={downloadLink("tsv")} download={downloadName("tsv")} target="_self">
-          Download as TSV File
-        </Link>
-      ) : (
-        "Download as TSV File"
-      )}
-    </Menu.Item>,
-    <Menu.Item key="download_excel" disabled={isQueryResultEmpty}>
-      {!isQueryResultEmpty ? (
-        <Link href={downloadLink("xlsx")} download={downloadName("xlsx")} target="_self">
-          Download as Excel File
-        </Link>
-      ) : (
-        "Download as Excel File"
-      )}
-    </Menu.Item>,
-    (canViewQuery || canEditParameters) && <Menu.Divider key="divider" />,
-    canViewQuery && (
-      <Menu.Item key="view_query">
-        <Link href={widget.getQuery().getUrl(true, widget.visualization.id)}>View Query</Link>
-      </Menu.Item>
-    ),
-    canEditParameters && (
-      <Menu.Item key="edit_parameters" onClick={onParametersEdit}>
-        Edit Parameters
-      </Menu.Item>
-    ),
-  ]);
-}
 
 function RefreshIndicator({ refreshStartedAt }) {
   return (
@@ -98,22 +42,35 @@ function VisualizationWidgetHeader({
   isEditing,
   onParametersUpdate,
   onParametersEdit,
+  showHeader,
 }) {
-  const canViewQuery = currentUser.hasPermission("view_query");
+  const vizConfig = registeredVisualizations[widget.visualization.type];
+  const chartName = widget.visualization.name;
+  const defaultName = vizConfig ? vizConfig.name : "";
+  const queryName = widget.getQuery().name;
+  const description = widget.getQuery().description;
+  const hasChartName = chartName && chartName !== defaultName;
+  const showDescription = !!description && description.trim() !== "";
 
   return (
     <>
       <RefreshIndicator refreshStartedAt={refreshStartedAt} />
       <div className="t-header widget clearfix">
         <div className="th-title">
-          <p>
-            <QueryLink query={widget.getQuery()} visualization={widget.visualization} readOnly={!canViewQuery} />
-          </p>
-          {!isEmpty(widget.getQuery().description) && (
-            <HtmlContent className="text-muted markdown query--description">
-              {markdown.toHTML(widget.getQuery().description || "")}
-            </HtmlContent>
-          )}
+          <span>
+            {hasChartName ? chartName : queryName}
+            {showHeader && hasChartName && queryName && (
+              <span> - {queryName}</span>
+            )}
+            {showHeader && showDescription && (
+              <>
+                <span> - </span>
+                <HtmlContent className="text-muted markdown query--description" style={{ display: "inline" }}>
+                  {markdown.toHTML(description)}
+                </HtmlContent>
+              </>
+            )}
+          </span>
         </div>
       </div>
       {!isEmpty(parameters) && (
@@ -138,6 +95,7 @@ VisualizationWidgetHeader.propTypes = {
   isEditing: PropTypes.bool,
   onParametersUpdate: PropTypes.func,
   onParametersEdit: PropTypes.func,
+  showHeader: PropTypes.bool,
 };
 
 VisualizationWidgetHeader.defaultProps = {
@@ -146,6 +104,7 @@ VisualizationWidgetHeader.defaultProps = {
   onParametersEdit: () => {},
   isEditing: false,
   parameters: [],
+  showHeader: true,
 };
 
 function VisualizationWidgetFooter({ widget, isPublic, onRefresh, onExpand }) {
@@ -214,8 +173,8 @@ VisualizationWidgetFooter.defaultProps = { isPublic: false };
 
 class VisualizationWidget extends React.Component {
   static propTypes = {
-    widget: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-    dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+    widget: PropTypes.object.isRequired,
+    dashboard: PropTypes.object.isRequired,
     filters: FiltersType,
     isPublic: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -225,6 +184,8 @@ class VisualizationWidget extends React.Component {
     onRefresh: PropTypes.func,
     onDelete: PropTypes.func,
     onParameterMappingsChange: PropTypes.func,
+    onOptionsChange: PropTypes.func,
+    backgroundColor: PropTypes.string,
   };
 
   static defaultProps = {
@@ -237,44 +198,163 @@ class VisualizationWidget extends React.Component {
     onRefresh: () => {},
     onDelete: () => {},
     onParameterMappingsChange: () => {},
+    onOptionsChange: () => {},
+    backgroundColor: null,
   };
 
   constructor(props) {
     super(props);
+    const { widget } = props;
     this.state = {
-      localParameters: props.widget.getLocalParameters(),
-      localFilters: props.filters,
+      localParameters: null,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refreshStartedAt: null,
+      parameterMappings: {},
+      showParameterMappingsForm: false,
+      showExpandedWidget: false,
+      showHeader: widget.options?.showHeader ?? true,
     };
   }
 
   componentDidMount() {
-    const { widget, onLoad } = this.props;
-    recordEvent("view", "query", widget.visualization.query.id, { dashboard: true });
-    recordEvent("view", "visualization", widget.visualization.id, { dashboard: true });
-    onLoad();
+    this.props.onLoad();
+    this._mounted = true;
   }
 
-  onLocalFiltersChange = localFilters => {
-    this.setState({ localFilters });
+  componentWillUnmount() {
+    this._mounted = false;
+    this.unregisterWidget();
+  }
+
+  visualizationWidgetMenuOptions = () => {
+    const { widget, canEdit } = this.props;
+    const { showHeader } = this.state;
+    const { onRefresh, onParameterMappingsChange } = this.props;
+
+    const canEditParameters = canEdit && !isEmpty(invoke(widget, "query.getParametersDefs"));
+    const widgetQueryResult = widget.getQueryResult();
+    const isQueryResultEmpty = !widgetQueryResult || !widgetQueryResult.isEmpty || widgetQueryResult.isEmpty();
+
+    const downloadLink = fileType => widgetQueryResult.getLink(widget.getQuery().id, fileType);
+    const downloadName = fileType => widgetQueryResult.getName(widget.getQuery().name, fileType);
+
+    const toggleHeader = () => {
+      const newOptions = {
+        ...widget.options,
+        showHeader: !showHeader,
+      };
+      widget.save('options', newOptions).then(() => {
+        this.setState({ showHeader: !showHeader });
+        if (typeof onRefresh === 'function') {
+          onRefresh();
+        }
+        if (typeof onParameterMappingsChange === 'function') {
+          onParameterMappingsChange();
+        }
+      });
+    };
+
+    return compact([
+      <Menu.Item key="toggle_header" onClick={toggleHeader}>
+        {showHeader ? "Hide Query" : "Show Query"}
+      </Menu.Item>,
+      <Menu.Divider key="divider1" />,
+      <Menu.Item key="download_csv" disabled={isQueryResultEmpty}>
+        {!isQueryResultEmpty ? (
+          <Link href={downloadLink("csv")} download={downloadName("csv")} target="_self">
+            Download as CSV File
+          </Link>
+        ) : (
+          "Download as CSV File"
+        )}
+      </Menu.Item>,
+      <Menu.Item key="download_tsv" disabled={isQueryResultEmpty}>
+        {!isQueryResultEmpty ? (
+          <Link href={downloadLink("tsv")} download={downloadName("tsv")} target="_self">
+            Download as TSV File
+          </Link>
+        ) : (
+          "Download as TSV File"
+        )}
+      </Menu.Item>,
+      <Menu.Item key="download_excel" disabled={isQueryResultEmpty}>
+        {!isQueryResultEmpty ? (
+          <Link href={downloadLink("xlsx")} download={downloadName("xlsx")} target="_self">
+            Download as Excel File
+          </Link>
+        ) : (
+          "Download as Excel File"
+        )}
+      </Menu.Item>,
+      (canEditParameters) && <Menu.Divider key="divider2" />,
+      canEditParameters && (
+        <Menu.Item key="edit_parameters" onClick={this.editParameterMappings}>
+          Edit Parameter Mapping
+        </Menu.Item>
+      ),
+    ]);
+  }
+
+  editParameterMappings = () => {
+    const { widget } = this.props;
+    const query = widget.getQuery();
+    const parameters = query.getParametersDefs();
+
+    EditParameterMappingsDialog.showModal({
+      dashboard: this.props.dashboard,
+      widget: this.props.widget,
+      parameters,
+      parameterMappings: this.state.parameterMappings,
+      onChange: this.props.onParameterMappingsChange,
+    }).result.finally(() => {
+      this.forceUpdate();
+      if (typeof this.props.onParameterMappingsChange === 'function') {
+        this.props.onParameterMappingsChange();
+      }
+    });
+  };
+
+  onParametersEdit = parameters => {
+    const { widget, onRefresh } = this.props;
+    const paramOrder = map(parameters, "name");
+    widget.options.paramOrder = paramOrder;
+    widget.save("options", { paramOrder }).then(() => {
+      if (typeof onRefresh === 'function') {
+        onRefresh();
+      }
+      this.forceUpdate();
+    }).catch(() => {
+      notification.error("Could not save parameter order.");
+    });
+  };
+
+  getParameters() {
+    try {
+      const { widget, filters } = this.props;
+      const { localParameters } = this.state;
+      return invoke(widget, 'getParameters', filters, localParameters);
+    } catch (error) {
+      // Handle error silently
+      return [];
+    }
+  }
+
+  onParametersUpdate = () => {
+    this.props.onRefresh();
   };
 
   expandWidget = () => {
-    ExpandedWidgetDialog.showModal({ widget: this.props.widget, filters: this.state.localFilters });
+    this.setState({ showExpandedWidget: true });
   };
 
-  editParameterMappings = () => {
-    const { widget, dashboard, onRefresh, onParameterMappingsChange } = this.props;
-    EditParameterMappingsDialog.showModal({
-      dashboard,
-      widget,
-    }).onClose(valuesChanged => {
-      // refresh widget if any parameter value has been updated
-      if (valuesChanged) {
-        onRefresh();
-      }
-      onParameterMappingsChange();
-      this.setState({ localParameters: widget.getLocalParameters() });
-    });
+  onRefresh = () => {
+    return this.props.onRefresh();
+  };
+
+  unregisterWidget = () => {
+    // Clean up code if needed
   };
 
   renderVisualization() {
@@ -301,6 +381,7 @@ class VisualizationWidget extends React.Component {
               filters={filters}
               onFiltersChange={this.onLocalFiltersChange}
               context="widget"
+              backgroundColor={this.props.backgroundColor}
             />
           </div>
         );
@@ -321,46 +402,50 @@ class VisualizationWidget extends React.Component {
   }
 
   render() {
-    const { widget, isLoading, isPublic, canEdit, isEditing, onRefresh } = this.props;
-    const { localParameters } = this.state;
+    const { widget, isPublic, /* canEdit, isLoading: isLoadingWidget */ } = this.props; // Commented out unused destructured props
+    const {
+      // isLoading: isLoadingData, // Unused state variable
+      // isError, // Unused state variable
+      // error, // Unused state variable
+      refreshStartedAt,
+      // showParameterMappingsForm, // Unused state variable
+      // showExpandedWidget, // Unused state variable
+      showHeader,
+    } = this.state;
+
     const widgetQueryResult = widget.getQueryResult();
-    const isRefreshing = isLoading && !!(widgetQueryResult && widgetQueryResult.getStatus());
-    const onParametersEdit = parameters => {
-      const paramOrder = map(parameters, "name");
-      widget.options.paramOrder = paramOrder;
-      widget.save("options", { paramOrder });
-    };
+    const isRefreshing = !!(widget.loading && widgetQueryResult && widgetQueryResult.getStatus());
+    const parameters = this.getParameters();
 
     return (
-      <Widget
-        {...this.props}
-        className="widget-visualization"
-        menuOptions={visualizationWidgetMenuOptions({
-          widget,
-          canEditDashboard: canEdit,
-          onParametersEdit: this.editParameterMappings,
-        })}
-        header={
-          <VisualizationWidgetHeader
-            widget={widget}
-            refreshStartedAt={isRefreshing ? widget.refreshStartedAt : null}
-            parameters={localParameters}
-            isEditing={isEditing}
-            onParametersUpdate={onRefresh}
-            onParametersEdit={onParametersEdit}
-          />
-        }
-        footer={
-          <VisualizationWidgetFooter
-            widget={widget}
-            isPublic={isPublic}
-            onRefresh={onRefresh}
-            onExpand={this.expandWidget}
-          />
-        }
-        tileProps={{ "data-refreshing": isRefreshing }}>
-        {this.renderVisualization()}
-      </Widget>
+      <>
+        <Widget
+          {...this.props}
+          className="widget-visualization"
+          menuOptions={this.visualizationWidgetMenuOptions()}
+          header={
+            <VisualizationWidgetHeader
+              widget={widget}
+              refreshStartedAt={refreshStartedAt}
+              parameters={parameters}
+              isEditing={this.props.isEditing}
+              onParametersUpdate={this.onParametersUpdate}
+              onParametersEdit={this.onParametersEdit}
+              showHeader={showHeader}
+            />
+          }
+          footer={
+            <VisualizationWidgetFooter
+              widget={widget}
+              isPublic={isPublic}
+              onRefresh={this.onRefresh}
+              onExpand={this.expandWidget}
+            />
+          }
+          tileProps={{ "data-refreshing": isRefreshing }}>
+          {this.renderVisualization()}
+        </Widget>
+      </>
     );
   }
 }

--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -59,9 +59,7 @@ function VisualizationWidgetHeader({
         <div className="th-title">
           <span>
             {hasChartName ? chartName : queryName}
-            {showHeader && hasChartName && queryName && (
-              <span> - {queryName}</span>
-            )}
+            {showHeader && hasChartName && queryName && <span> - {queryName}</span>}
             {showHeader && showDescription && (
               <>
                 <span> - </span>
@@ -245,12 +243,12 @@ class VisualizationWidget extends React.Component {
         ...widget.options,
         showHeader: !showHeader,
       };
-      widget.save('options', newOptions).then(() => {
+      widget.save("options", newOptions).then(() => {
         this.setState({ showHeader: !showHeader });
-        if (typeof onRefresh === 'function') {
+        if (typeof onRefresh === "function") {
           onRefresh();
         }
-        if (typeof onParameterMappingsChange === 'function') {
+        if (typeof onParameterMappingsChange === "function") {
           onParameterMappingsChange();
         }
       });
@@ -288,14 +286,14 @@ class VisualizationWidget extends React.Component {
           "Download as Excel File"
         )}
       </Menu.Item>,
-      (canEditParameters) && <Menu.Divider key="divider2" />,
+      canEditParameters && <Menu.Divider key="divider2" />,
       canEditParameters && (
         <Menu.Item key="edit_parameters" onClick={this.editParameterMappings}>
           Edit Parameter Mapping
         </Menu.Item>
       ),
     ]);
-  }
+  };
 
   editParameterMappings = () => {
     const { widget } = this.props;
@@ -310,7 +308,7 @@ class VisualizationWidget extends React.Component {
       onChange: this.props.onParameterMappingsChange,
     }).result.finally(() => {
       this.forceUpdate();
-      if (typeof this.props.onParameterMappingsChange === 'function') {
+      if (typeof this.props.onParameterMappingsChange === "function") {
         this.props.onParameterMappingsChange();
       }
     });
@@ -320,21 +318,24 @@ class VisualizationWidget extends React.Component {
     const { widget, onRefresh } = this.props;
     const paramOrder = map(parameters, "name");
     widget.options.paramOrder = paramOrder;
-    widget.save("options", { paramOrder }).then(() => {
-      if (typeof onRefresh === 'function') {
-        onRefresh();
-      }
-      this.forceUpdate();
-    }).catch(() => {
-      notification.error("Could not save parameter order.");
-    });
+    widget
+      .save("options", { paramOrder })
+      .then(() => {
+        if (typeof onRefresh === "function") {
+          onRefresh();
+        }
+        this.forceUpdate();
+      })
+      .catch(() => {
+        notification.error("Could not save parameter order.");
+      });
   };
 
   getParameters() {
     try {
       const { widget, filters } = this.props;
       const { localParameters } = this.state;
-      return invoke(widget, 'getParameters', filters, localParameters);
+      return invoke(widget, "getParameters", filters, localParameters);
     } catch (error) {
       // Handle error silently
       return [];
@@ -402,7 +403,7 @@ class VisualizationWidget extends React.Component {
   }
 
   render() {
-    const { widget, isPublic, /* canEdit, isLoading: isLoadingWidget */ } = this.props; // Commented out unused destructured props
+    const { widget, isPublic /* canEdit, isLoading: isLoadingWidget */ } = this.props; // Commented out unused destructured props
     const {
       // isLoading: isLoadingData, // Unused state variable
       // isError, // Unused state variable

--- a/client/app/components/dashboards/dashboard-widget/Widget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/Widget.jsx
@@ -5,7 +5,6 @@ import { isEmpty } from "lodash";
 import Dropdown from "antd/lib/dropdown";
 import Modal from "antd/lib/modal";
 import Menu from "antd/lib/menu";
-import recordEvent from "@/services/recordEvent";
 import { Moment } from "@/components/proptypes";
 import PlainButton from "@/components/PlainButton";
 
@@ -69,10 +68,12 @@ class Widget extends React.Component {
     header: PropTypes.node,
     footer: PropTypes.node,
     canEdit: PropTypes.bool,
+    isPublic: PropTypes.bool,
     refreshStartedAt: Moment,
     menuOptions: PropTypes.node,
     tileProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     onDelete: PropTypes.func,
+    onLoad: PropTypes.func,
   };
 
   static defaultProps = {
@@ -81,15 +82,16 @@ class Widget extends React.Component {
     header: null,
     footer: null,
     canEdit: false,
+    isPublic: false,
     refreshStartedAt: null,
     menuOptions: null,
     tileProps: {},
     onDelete: () => {},
+    onLoad: () => {},
   };
 
   componentDidMount() {
-    const { widget } = this.props;
-    recordEvent("view", "widget", widget.id);
+    this.props.onLoad();
   }
 
   deleteWidget = () => {
@@ -107,8 +109,8 @@ class Widget extends React.Component {
   };
 
   render() {
-    const { className, children, header, footer, canEdit, menuOptions, tileProps } = this.props;
-    const showDropdownButton = (canEdit || !isEmpty(menuOptions));
+    const { className, children, header, footer, canEdit, isPublic, menuOptions, tileProps } = this.props;
+    const showDropdownButton = !isPublic && (canEdit || !isEmpty(menuOptions));
     return (
       <div className="widget-wrapper">
         <div className={cx("tile body-container", className)} {...tileProps}>

--- a/client/app/components/dashboards/dashboard-widget/Widget.less
+++ b/client/app/components/dashboards/dashboard-widget/Widget.less
@@ -38,6 +38,7 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    background-color: var(--dashboard-background-color, #ffffff);
 
     .body-row {
       flex: 0 1 auto;
@@ -45,6 +46,14 @@
 
     .body-row-auto {
       flex: 1 1 auto;
+    }
+
+    .widget-header {
+      background-color: var(--dashboard-background-color, #ffffff);
+    }
+
+    .tile__bottom-control {
+      background-color: var(--dashboard-background-color, #ffffff);
     }
   }
 

--- a/client/app/components/dashboards/dashboard-widget/__tests__/VisualizationWidget.test.jsx
+++ b/client/app/components/dashboards/dashboard-widget/__tests__/VisualizationWidget.test.jsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { mount } from "enzyme";
+// import { includes } from "lodash";
+// import { Menu } from "antd";
+// import { mockNotification } from "@/services/notification"; // Mock before loading auth
+import { render, screen, fireEvent } from "@testing-library/react";
+import VisualizationWidget from "../VisualizationWidget";
+
+// Mock services
+// const mockAuth = {
+//   Auth: {
+//     hasPermission: jest.fn(() => true),
+//   },
+// };
+
+jest.mock("@/services/user");
+jest.mock("@/services/organization");
+jest.mock("@/services/notification");
+
+// Mock window.URL.createObjectURL
+// Object.defineProperty(window.URL, 'createObjectURL', {
+//   writable: true,
+//   value: jest.fn(() => 'mocked-url')
+// });
+
+// Mock modules before imports
+// jest.mock("plotly.js", () => ({
+//   newPlot: jest.fn(),
+//   react: jest.fn(),
+// }));
+
+// jest.mock("mapbox-gl", () => ({
+//   Map: jest.fn(),
+// }));
+
+// import { render, screen, fireEvent } from "@testing-library/react";
+// import VisualizationWidget from "../VisualizationWidget";
+
+// Mock visualization components
+jest.mock("@/components/visualizations/VisualizationRenderer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="visualization-renderer">Test Visualization</div>,
+}));
+
+// Mock QueryLink component
+jest.mock("@/components/QueryLink", () => ({
+  __esModule: true,
+  default: () => <div data-testid="query-link">Query Link</div>,
+}));
+
+const mockWidget = {
+  id: 1,
+  width: 100,
+  options: {
+    position: { col: 0, row: 0, sizeX: 3, sizeY: 2 },
+    showHeader: true,
+  },
+  visualization: {
+    query: { id: 123, name: 'Test Query' },
+    name: 'Test Visualization',
+  },
+};
+
+const defaultProps = {
+  widget: mockWidget,
+  isEditing: false,
+  canEdit: true,
+  onMoveWidget: jest.fn(),
+  onRemoveWidget: jest.fn(),
+  onResizeStop: jest.fn(),
+  onParameterMappingsChange: jest.fn(),
+};
+
+describe("VisualizationWidget", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Header Visibility", () => {
+    it("shows header by default", () => {
+      render(<VisualizationWidget {...defaultProps} />);
+      
+      // Header should contain query name
+      expect(screen.getByText("Test Query")).toBeInTheDocument();
+    });
+
+    it("hides header when widget.options.showHeader is false", () => {
+      const props = {
+        ...defaultProps,
+        widget: {
+          ...mockWidget,
+          options: { showHeader: false },
+        },
+      };
+      
+      render(<VisualizationWidget {...props} />);
+      
+      // Header should not be present
+      expect(screen.queryByText("Test Query")).not.toBeInTheDocument();
+    });
+
+    it("toggles header visibility through menu option", () => {
+      const widget = {
+        ...mockWidget,
+        options: { showHeader: true },
+      };
+
+      const wrapper = mount(
+        <VisualizationWidget
+          {...defaultProps}
+          widget={widget}
+        />
+      );
+
+      // Initially header should be visible
+      expect(wrapper.find("VisualizationWidgetHeader")).toHaveLength(1);
+
+      // Find and click the toggle header menu item
+      const toggleButton = wrapper.find('MenuItem[key="toggle_header"]');
+      toggleButton.simulate("click");
+
+      // Should call save with updated options
+      expect(widget.save).toHaveBeenCalledWith("options", {
+        showHeader: false,
+      });
+    });
+
+    it("preserves other widget options when toggling header", () => {
+      const widget = {
+        ...mockWidget,
+        options: {
+          showHeader: true,
+          someOtherOption: "value",
+        },
+      };
+
+      const wrapper = mount(
+        <VisualizationWidget
+          {...defaultProps}
+          widget={widget}
+        />
+      );
+
+      // Find and click the toggle header menu item
+      const toggleButton = wrapper.find('MenuItem[key="toggle_header"]');
+      toggleButton.simulate("click");
+
+      // Should call save with all options preserved
+      expect(widget.save).toHaveBeenCalledWith("options", {
+        showHeader: false,
+        someOtherOption: "value",
+      });
+    });
+  });
+
+  it("renders with header visible by default", () => {
+    render(<VisualizationWidget {...defaultProps} />);
+    expect(screen.getByText('Test Visualization')).toBeInTheDocument();
+  });
+
+  it("hides header when showHeader is false", () => {
+    const widgetWithHiddenHeader = {
+      ...mockWidget,
+      options: { ...mockWidget.options, showHeader: false },
+    };
+    render(<VisualizationWidget {...defaultProps} widget={widgetWithHiddenHeader} />);
+    expect(screen.queryByText('Test Visualization')).not.toBeInTheDocument();
+  });
+
+  it("shows header toggle option in menu when editing", () => {
+    render(<VisualizationWidget {...defaultProps} isEditing={true} />);
+    fireEvent.click(screen.getByRole('button', { name: /menu/i }));
+    expect(screen.getByText(/toggle header/i)).toBeInTheDocument();
+  });
+
+  it("preserves other widget options when toggling header", () => {
+    render(<VisualizationWidget {...defaultProps} isEditing={true} />);
+    fireEvent.click(screen.getByRole('button', { name: /menu/i }));
+    fireEvent.click(screen.getByText(/toggle header/i));
+    expect(defaultProps.onParameterMappingsChange).toHaveBeenCalledWith({
+      ...mockWidget.options,
+      showHeader: false,
+    });
+  });
+}); 

--- a/client/app/components/items-list/classes/ItemsSource.js
+++ b/client/app/components/items-list/classes/ItemsSource.js
@@ -59,7 +59,7 @@ export class ItemsSource {
             return this._afterUpdate();
           }
         })
-        .catch(error => this.handleError(error));
+        .catch((error) => this.handleError(error));
     });
   }
 

--- a/client/app/components/visualizations/EditVisualizationDialog.jsx
+++ b/client/app/components/visualizations/EditVisualizationDialog.jsx
@@ -44,7 +44,7 @@ function saveVisualization(visualization) {
       notification.success("Visualization saved");
       return result;
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Visualization could not be saved");
       return Promise.reject(error);
     });

--- a/client/app/components/visualizations/VisualizationRenderer.jsx
+++ b/client/app/components/visualizations/VisualizationRenderer.jsx
@@ -69,9 +69,9 @@ export default function VisualizationRenderer(props) {
     [data, filters]
   );
 
-  const { showFilters, visualization } = props;
+  const { showFilters, visualization, backgroundColor } = props;
 
-  let options = { ...visualization.options };
+  let options = { ...visualization.options, backgroundColor };
 
   // define pagination size based on context for Table visualization
   if (visualization.type === "TABLE") {
@@ -97,10 +97,12 @@ VisualizationRenderer.propTypes = {
   filters: FiltersType,
   onFiltersChange: PropTypes.func,
   context: PropTypes.oneOf(["query", "widget"]).isRequired,
+  backgroundColor: PropTypes.string,
 };
 
 VisualizationRenderer.defaultProps = {
   showFilters: true,
   filters: [],
   onFiltersChange: () => {},
+  backgroundColor: null,
 };

--- a/client/app/pages/admin/Jobs.jsx
+++ b/client/app/pages/admin/Jobs.jsx
@@ -44,7 +44,7 @@ class Jobs extends React.Component {
     axios
       .get("/api/admin/queries/rq_status")
       .then(data => this.processQueues(data))
-      .catch(error => this.handleError(error));
+      .catch((error) => this.handleError(error));
 
     this._refreshTimer = setTimeout(this.refresh, 60 * 1000);
   };

--- a/client/app/pages/admin/SystemStatus.jsx
+++ b/client/app/pages/admin/SystemStatus.jsx
@@ -54,7 +54,7 @@ class SystemStatus extends React.Component {
           status: omit(data, ["workers", "manager", "database_metrics"]),
         });
       })
-      .catch(error => this.props.onError(error));
+      .catch((error) => this.props.onError(error));
     this._refreshTimer = setTimeout(this.refresh, 60 * 1000);
   };
 

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -1,45 +1,89 @@
-import { isEmpty, map } from "lodash";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-
+import { isEmpty, debounce, isEqual } from "lodash";
 import Button from "antd/lib/button";
-import Checkbox from "antd/lib/checkbox";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
-import DynamicComponent from "@/components/DynamicComponent";
 import DashboardGrid from "@/components/dashboards/DashboardGrid";
-import Parameters from "@/components/Parameters";
+import DashboardHeader from "./components/DashboardHeader";
 import Filters from "@/components/Filters";
 
 import { Dashboard } from "@/services/dashboard";
 import recordEvent from "@/services/recordEvent";
-import resizeObserver from "@/services/resizeObserver";
 import routes from "@/services/routes";
 import location from "@/services/location";
 import url from "@/services/url";
-import useImmutableCallback from "@/lib/hooks/useImmutableCallback";
 
-import useDashboard from "./hooks/useDashboard";
-import DashboardHeader from "./components/DashboardHeader";
+import { useDashboard } from "./hooks/useDashboard";
 
 import "./DashboardPage.less";
 
-function DashboardSettings({ dashboardConfiguration }) {
-  const { dashboard, updateDashboard } = dashboardConfiguration;
+function DashboardSettings({ dashboard, updateDashboard }) {
+  const [localBackgroundColor, setLocalBackgroundColor] = useState(
+    dashboard.options?.backgroundColor || '#ffffff'
+  );
+
+  const debouncedUpdate = useCallback(
+    debounce((color) => {
+      const newOptions = {
+        ...dashboard.options,
+        backgroundColor: color,
+      };
+      updateDashboard({ options: newOptions });
+    }, 300),
+    [dashboard.options, updateDashboard]
+  );
+
+  const handleBackgroundColorChange = e => {
+    const color = e.target.value;
+    setLocalBackgroundColor(color);
+    debouncedUpdate(color);
+  };
+
+  const handleBackgroundColorChangeComplete = e => {
+    const color = e.target.value;
+    const newOptions = {
+      ...dashboard.options,
+      backgroundColor: color,
+    };
+    updateDashboard({ options: newOptions });
+  };
+
   return (
     <div className="m-b-10 p-15 bg-white tiled">
-      <Checkbox
-        checked={!!dashboard.dashboard_filters_enabled}
-        onChange={({ target }) => updateDashboard({ dashboard_filters_enabled: target.checked })}
-        data-test="DashboardFiltersCheckbox">
-        Use Dashboard Level Filters
-      </Checkbox>
+      <h4 className="m-t-0">Dashboard Settings</h4>
+      <div className="m-t-10 m-b-10">
+        <div className="dashboard-settings-row">
+          <div className="form-group dashboard-settings-filters">
+            <label htmlFor="dashboard-filters-enabled">
+              <input
+                type="checkbox"
+                id="dashboard-filters-enabled"
+                checked={!!dashboard.dashboard_filters_enabled}
+                onChange={e => updateDashboard({ dashboard_filters_enabled: e.target.checked })}
+              />
+              <span>Use Dashboard Level Filters</span>
+            </label>
+          </div>
+          <div className="form-group dashboard-settings-color align-right">
+            <label htmlFor="dashboard-background-color">Background Color</label>
+            <input
+              id="dashboard-background-color"
+              type="color"
+              value={localBackgroundColor}
+              onChange={handleBackgroundColorChange}
+              onChangeComplete={handleBackgroundColorChangeComplete}
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
 
 DashboardSettings.propTypes = {
-  dashboardConfiguration: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  dashboard: PropTypes.object.isRequired,
+  updateDashboard: PropTypes.func.isRequired,
 };
 
 function AddWidgetContainer({ dashboardConfiguration, className, ...props }) {
@@ -70,108 +114,181 @@ AddWidgetContainer.propTypes = {
   className: PropTypes.string,
 };
 
+export function normalizeLayout(layout) {
+  // Convert dict/object to array if needed
+  if (!Array.isArray(layout) && typeof layout === "object" && layout !== null) {
+    layout = Object.values(layout);
+  }
+  if (!Array.isArray(layout)) return [];
+  return layout
+    .filter(item => item && typeof item.i === "string")
+    .map(item => ({
+      i: item.i,
+      x: item.x,
+      y: item.y,
+      w: item.w,
+      h: item.h,
+      // add more keys if needed
+    }))
+    .sort((a, b) => a.i.localeCompare(b.i));
+}
+
 function DashboardComponent(props) {
   const dashboardConfiguration = useDashboard(props.dashboard);
-  const {
-    dashboard,
-    filters,
-    setFilters,
-    loadDashboard,
-    loadWidget,
-    removeWidget,
-    saveDashboardLayout,
-    globalParameters,
-    updateDashboard,
-    refreshDashboard,
-    refreshWidget,
-    editingLayout,
-    setGridDisabled,
-  } = dashboardConfiguration;
-
-  const [pageContainer, setPageContainer] = useState(null);
-  const [bottomPanelStyles, setBottomPanelStyles] = useState({});
-  const onParametersEdit = parameters => {
-    const paramOrder = map(parameters, "name");
-    updateDashboard({ options: { globalParamOrder: paramOrder } });
-  };
+  const { dashboard, updateDashboard, loadWidget, refreshWidget, removeWidget, canEditDashboard } = dashboardConfiguration;
+  const [filters, setFilters] = useState([]);
+  const [editingLayout, setEditingLayout] = useState(props.editMode);
+  const [gridDisabled, setGridDisabled] = useState(false);
+  const [isPublic] = useState(false); // Default to false since this is the private dashboard view
 
   useEffect(() => {
-    if (pageContainer) {
-      const unobserve = resizeObserver(pageContainer, () => {
-        if (editingLayout) {
-          const style = window.getComputedStyle(pageContainer, null);
-          const bounds = pageContainer.getBoundingClientRect();
-          const paddingLeft = parseFloat(style.paddingLeft) || 0;
-          const paddingRight = parseFloat(style.paddingRight) || 0;
-          setBottomPanelStyles({
-            left: Math.round(bounds.left) + paddingRight,
-            width: pageContainer.clientWidth - paddingLeft - paddingRight,
-          });
-        }
+    setEditingLayout(props.editMode);
+  }, [props.editMode]);
 
-        // reflow grid when container changes its size
-        window.dispatchEvent(new Event("resize"));
-      });
-      return unobserve;
+  useEffect(() => {
+    recordEvent("view", "dashboard", dashboard.id);
+  }, [dashboard.id]);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshDashboard = useCallback(() => {
+    if (!refreshing) {
+      setRefreshing(true);
+      const promises = dashboard.widgets.map(widget => refreshWidget(widget).catch(() => {}));
+      Promise.all(promises).finally(() => setRefreshing(false));
     }
-  }, [pageContainer, editingLayout]);
+  }, [refreshing, dashboard, refreshWidget]);
+
+  useEffect(() => {
+    const refreshDashboardIfNeeded = () => {
+      if (document.hidden) {
+        return;
+      }
+      const interval = dashboard.dashboard_filters_refresh_interval;
+      if (interval) {
+        refreshDashboard();
+      }
+    };
+    document.addEventListener("visibilitychange", refreshDashboardIfNeeded);
+    return () => {
+      document.removeEventListener("visibilitychange", refreshDashboardIfNeeded);
+    };
+  }, [dashboard.dashboard_filters_refresh_interval, refreshDashboard]);
+
+  const onParameterMappingsChange = useCallback(() => {
+    // Refresh dashboard when parameter mappings change
+    refreshDashboard();
+  }, [refreshDashboard]);
+
+  // Only update dashboard if layout has changed, and debounce the save
+  const debouncedUpdateDashboard = useCallback(debounce(updateDashboard, 300), [updateDashboard]);
+  const handleLayoutChange = useCallback((newLayout) => {
+    // Convert object to array if needed
+    let layoutArray = newLayout;
+    if (!Array.isArray(newLayout) && typeof newLayout === "object" && newLayout !== null) {
+      layoutArray = Object.entries(newLayout).map(([i, pos]) => ({
+        i,
+        x: pos.col,
+        y: pos.row,
+        w: pos.sizeX,
+        h: pos.sizeY
+      }));
+    }
+    // console.log('[handleLayoutChange] layoutArray:', layoutArray);
+    const normNew = normalizeLayout(layoutArray);
+    const normCurrent = normalizeLayout(dashboard.layout);
+
+    // Check if any positions have actually changed
+    const hasPositionChanges = normNew.some(newItem => {
+      const currentItem = normCurrent.find(c => c.i === newItem.i);
+      if (!currentItem) return true;
+      return newItem.x !== currentItem.x || 
+             newItem.y !== currentItem.y || 
+             newItem.w !== currentItem.w || 
+             newItem.h !== currentItem.h;
+    });
+
+    if (hasPositionChanges) {
+      // console.log('[handleLayoutChange] Saving dashboard layout changes');
+      Object.freeze(normNew);
+      debouncedUpdateDashboard({ layout: normNew });
+    }
+  }, [dashboard.layout, debouncedUpdateDashboard]);
 
   return (
-    <div className="container" ref={setPageContainer} data-test={`DashboardId${dashboard.id}Container`}>
+    <>
       <DashboardHeader
-        dashboardConfiguration={dashboardConfiguration}
-        headerExtra={
-          <DynamicComponent
-            name="Dashboard.HeaderExtra"
-            dashboard={dashboard}
-            dashboardConfiguration={dashboardConfiguration}
-          />
-        }
+        dashboardConfiguration={{
+          dashboard,
+          editingLayout,
+          updateDashboard,
+          togglePublished: props.togglePublished,
+          refreshing,
+          filters,
+          onRename: props.onRename,
+          onRefresh: refreshDashboard,
+          setEditingLayout,
+          gridDisabled,
+          setGridDisabled,
+          canEditDashboard,
+          fullscreen: false,
+          toggleFullscreen: () => {},
+          showShareDashboardDialog: () => {},
+          isDashboardOwnerOrAdmin: dashboard.canEdit(),
+          isDuplicating: false,
+          duplicateDashboard: () => {},
+          archiveDashboard: () => updateDashboard({ is_archived: true }),
+          managePermissions: () => {}
+        }}
+        headerExtra={null}
       />
-      {!isEmpty(globalParameters) && (
-        <div className="dashboard-parameters m-b-10 p-15 bg-white tiled" data-test="DashboardParameters">
-          <Parameters
-            parameters={globalParameters}
-            onValuesChange={refreshDashboard}
-            sortable={editingLayout}
-            onParametersEdit={onParametersEdit}
-          />
-        </div>
-      )}
-      {!isEmpty(filters) && (
-        <div className="m-b-10 p-15 bg-white tiled" data-test="DashboardFilters">
+      {!isEmpty(dashboard.widgets) && dashboard.dashboard_filters_enabled && (
+        <div className="m-b-10 p-15 bg-white tiled">
           <Filters filters={filters} onChange={setFilters} />
         </div>
       )}
-      {editingLayout && <DashboardSettings dashboardConfiguration={dashboardConfiguration} />}
-      <div id="dashboard-container">
+      {editingLayout && <DashboardSettings dashboard={dashboard} updateDashboard={updateDashboard} />}
+      <div id="dashboard-container" className="dashboard-wrapper">
         <DashboardGrid
           dashboard={dashboard}
           widgets={dashboard.widgets}
           filters={filters}
           isEditing={editingLayout}
-          onLayoutChange={editingLayout ? saveDashboardLayout : () => {}}
-          onBreakpointChange={setGridDisabled}
           onLoadWidget={loadWidget}
           onRefreshWidget={refreshWidget}
           onRemoveWidget={removeWidget}
-          onParameterMappingsChange={loadDashboard}
+          onBreakpointChange={setGridDisabled}
+          onLayoutChange={handleLayoutChange}
+          onParameterMappingsChange={onParameterMappingsChange}
+          isPublic={isPublic}
+          isLoading={refreshing}
         />
       </div>
       {editingLayout && (
-        <AddWidgetContainer dashboardConfiguration={dashboardConfiguration} style={bottomPanelStyles} />
+        <AddWidgetContainer
+          dashboardConfiguration={dashboardConfiguration}
+          className={cx("add-widget-container", { disabled: gridDisabled })}
+        />
       )}
-    </div>
+    </>
   );
 }
 
 DashboardComponent.propTypes = {
-  dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  dashboard: PropTypes.object.isRequired,
+  editMode: PropTypes.bool,
+  togglePublished: PropTypes.func,
+  onRename: PropTypes.func,
+};
+
+DashboardComponent.defaultProps = {
+  editMode: false,
+  togglePublished: () => {},
+  onRename: () => {},
 };
 
 function DashboardPage({ dashboardSlug, dashboardId, onError }) {
   const [dashboard, setDashboard] = useState(null);
-  const handleError = useImmutableCallback(onError);
+  const handleError = onError;
 
   useEffect(() => {
     Dashboard.get({ id: dashboardId, slug: dashboardSlug })

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -19,12 +19,10 @@ import { useDashboard } from "./hooks/useDashboard";
 import "./DashboardPage.less";
 
 function DashboardSettings({ dashboard, updateDashboard }) {
-  const [localBackgroundColor, setLocalBackgroundColor] = useState(
-    dashboard.options?.backgroundColor || '#ffffff'
-  );
+  const [localBackgroundColor, setLocalBackgroundColor] = useState(dashboard.options?.backgroundColor || "#ffffff");
 
   const debouncedUpdate = useCallback(
-    debounce((color) => {
+    debounce(color => {
       const newOptions = {
         ...dashboard.options,
         backgroundColor: color,
@@ -135,7 +133,14 @@ export function normalizeLayout(layout) {
 
 function DashboardComponent(props) {
   const dashboardConfiguration = useDashboard(props.dashboard);
-  const { dashboard, updateDashboard, loadWidget, refreshWidget, removeWidget, canEditDashboard } = dashboardConfiguration;
+  const {
+    dashboard,
+    updateDashboard,
+    loadWidget,
+    refreshWidget,
+    removeWidget,
+    canEditDashboard,
+  } = dashboardConfiguration;
   const [filters, setFilters] = useState([]);
   const [editingLayout, setEditingLayout] = useState(props.editMode);
   const [gridDisabled, setGridDisabled] = useState(false);
@@ -181,38 +186,43 @@ function DashboardComponent(props) {
 
   // Only update dashboard if layout has changed, and debounce the save
   const debouncedUpdateDashboard = useCallback(debounce(updateDashboard, 300), [updateDashboard]);
-  const handleLayoutChange = useCallback((newLayout) => {
-    // Convert object to array if needed
-    let layoutArray = newLayout;
-    if (!Array.isArray(newLayout) && typeof newLayout === "object" && newLayout !== null) {
-      layoutArray = Object.entries(newLayout).map(([i, pos]) => ({
-        i,
-        x: pos.col,
-        y: pos.row,
-        w: pos.sizeX,
-        h: pos.sizeY
-      }));
-    }
-    // console.log('[handleLayoutChange] layoutArray:', layoutArray);
-    const normNew = normalizeLayout(layoutArray);
-    const normCurrent = normalizeLayout(dashboard.layout);
+  const handleLayoutChange = useCallback(
+    newLayout => {
+      // Convert object to array if needed
+      let layoutArray = newLayout;
+      if (!Array.isArray(newLayout) && typeof newLayout === "object" && newLayout !== null) {
+        layoutArray = Object.entries(newLayout).map(([i, pos]) => ({
+          i,
+          x: pos.col,
+          y: pos.row,
+          w: pos.sizeX,
+          h: pos.sizeY,
+        }));
+      }
+      // console.log('[handleLayoutChange] layoutArray:', layoutArray);
+      const normNew = normalizeLayout(layoutArray);
+      const normCurrent = normalizeLayout(dashboard.layout);
 
-    // Check if any positions have actually changed
-    const hasPositionChanges = normNew.some(newItem => {
-      const currentItem = normCurrent.find(c => c.i === newItem.i);
-      if (!currentItem) return true;
-      return newItem.x !== currentItem.x || 
-             newItem.y !== currentItem.y || 
-             newItem.w !== currentItem.w || 
-             newItem.h !== currentItem.h;
-    });
+      // Check if any positions have actually changed
+      const hasPositionChanges = normNew.some(newItem => {
+        const currentItem = normCurrent.find(c => c.i === newItem.i);
+        if (!currentItem) return true;
+        return (
+          newItem.x !== currentItem.x ||
+          newItem.y !== currentItem.y ||
+          newItem.w !== currentItem.w ||
+          newItem.h !== currentItem.h
+        );
+      });
 
-    if (hasPositionChanges) {
-      // console.log('[handleLayoutChange] Saving dashboard layout changes');
-      Object.freeze(normNew);
-      debouncedUpdateDashboard({ layout: normNew });
-    }
-  }, [dashboard.layout, debouncedUpdateDashboard]);
+      if (hasPositionChanges) {
+        // console.log('[handleLayoutChange] Saving dashboard layout changes');
+        Object.freeze(normNew);
+        debouncedUpdateDashboard({ layout: normNew });
+      }
+    },
+    [dashboard.layout, debouncedUpdateDashboard]
+  );
 
   return (
     <>
@@ -237,7 +247,7 @@ function DashboardComponent(props) {
           isDuplicating: false,
           duplicateDashboard: () => {},
           archiveDashboard: () => updateDashboard({ is_archived: true }),
-          managePermissions: () => {}
+          managePermissions: () => {},
         }}
         headerExtra={null}
       />

--- a/client/app/pages/dashboards/DashboardPage.less
+++ b/client/app/pages/dashboards/DashboardPage.less
@@ -54,3 +54,31 @@
     align-self: center;
   }
 }
+
+.dashboard-settings-divider {
+  height: 1px;
+  background-color: #f0f0f0;
+  margin: 15px 0;
+}
+
+.dashboard-settings-color {
+  display: flex;
+  align-items: center;
+
+  label {
+    font-weight: 500;
+    color: #595959;
+    white-space: nowrap;
+  }
+
+  input[type="color"] {
+    margin-left: 8px;
+  }
+}
+
+.dashboard-wrapper {
+  flex-grow: 1;
+  margin-bottom: 70px;
+  background-color: var(--dashboard-background-color, #ffffff);
+  transition: background-color 0.2s ease;
+}

--- a/client/app/pages/dashboards/PublicDashboardPage.jsx
+++ b/client/app/pages/dashboards/PublicDashboardPage.jsx
@@ -74,7 +74,7 @@ class PublicDashboardPage extends React.Component {
   componentDidMount() {
     Dashboard.getByToken({ token: this.props.token })
       .then(dashboard => this.setState({ dashboard, loading: false }))
-      .catch(error => this.props.onError(error));
+      .catch((error) => this.props.onError(error));
   }
 
   render() {

--- a/client/app/pages/dashboards/PublicDashboardPage.jsx
+++ b/client/app/pages/dashboards/PublicDashboardPage.jsx
@@ -15,7 +15,7 @@ import routes from "@/services/routes";
 
 import logoUrl from "@/assets/images/redash_icon_small.png";
 
-import useDashboard from "./hooks/useDashboard";
+import { useDashboard } from "./hooks/useDashboard";
 
 import "./PublicDashboardPage.less";
 

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -1,0 +1,10 @@
+.dashboard-wrapper {
+  --dashboard-background-color: #ffffff;
+  flex-grow: 1;
+  margin-bottom: 70px;
+  background-color: var(--dashboard-background-color);
+
+  .layout {
+    margin: -15px -15px 0;
+  }
+} 

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -7,4 +7,4 @@
   .layout {
     margin: -15px -15px 0;
   }
-} 
+}

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -84,7 +84,7 @@ export function useDashboard(dashboardData) {
             location.setPath(url.parse(updatedDashboard.url).pathname, true);
           }
         })
-        .catch(error => {
+        .catch((error) => {
           const status = get(error, "response.status");
           if (status === 403) {
             notification.error("Dashboard update failed", "Permission Denied.");
@@ -109,7 +109,7 @@ export function useDashboard(dashboardData) {
     // console.log('[loadWidget] called for widget:', widget.id, 'forceRefresh:', forceRefresh);
     // console.trace('[loadWidget] call stack');
     widget.getParametersDefs(); // Force widget to read parameters values from URL
-    return widget.load(forceRefresh).catch(error => {
+    return widget.load(forceRefresh).catch((error) => {
       // QueryResultErrors are expected
       if (error instanceof QueryResultError) {
         return;
@@ -135,7 +135,7 @@ export function useDashboard(dashboardData) {
     (forceRefresh = false, updatedParameters = []) => {
       const affectedWidgets = getAffectedWidgets(dashboard.widgets, updatedParameters);
       const loadWidgetPromises = compact(
-        affectedWidgets.map(widget => loadWidget(widget, forceRefresh).catch(error => error))
+        affectedWidgets.map(widget => loadWidget(widget, forceRefresh).catch((error) => error))
       );
 
       return Promise.all(loadWidgetPromises).then(() => {

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -14,11 +14,12 @@ import { editableMappingsToParameterMappings, synchronizeWidgetTitles } from "@/
 import ShareDashboardDialog from "../components/ShareDashboardDialog";
 import useFullscreenHandler from "../../../lib/hooks/useFullscreenHandler";
 import useRefreshRateHandler from "./useRefreshRateHandler";
-import useEditModeHandler from "./useEditModeHandler";
+import useEditModeHandler, { DashboardStatusEnum } from "./useEditModeHandler";
 import useDuplicateDashboard from "./useDuplicateDashboard";
 import { policy } from "@/services/policy";
+import { normalizeLayout } from "../DashboardPage";
 
-export { DashboardStatusEnum } from "./useEditModeHandler";
+export { DashboardStatusEnum };
 
 function getAffectedWidgets(widgets, updatedParameters = []) {
   return !isEmpty(updatedParameters)
@@ -35,7 +36,7 @@ function getAffectedWidgets(widgets, updatedParameters = []) {
     : widgets;
 }
 
-function useDashboard(dashboardData) {
+export function useDashboard(dashboardData) {
   const [dashboard, setDashboard] = useState(dashboardData);
   const [filters, setFilters] = useState([]);
   const [refreshing, setRefreshing] = useState(false);
@@ -67,6 +68,10 @@ function useDashboard(dashboardData) {
 
   const updateDashboard = useCallback(
     (data, includeVersion = true) => {
+      // Normalize layout if present
+      if (data.layout) {
+        data.layout = normalizeLayout(data.layout);
+      }
       setDashboard(currentDashboard => extend({}, currentDashboard, data));
       data = { ...data, id: dashboard.id };
       if (includeVersion) {
@@ -85,8 +90,8 @@ function useDashboard(dashboardData) {
             notification.error("Dashboard update failed", "Permission Denied.");
           } else if (status === 409) {
             notification.error(
-              "It seems like the dashboard has been modified by another user. ",
-              "Please copy/backup your changes and reload this page.",
+              "Dashboard Version Conflict", 
+              "The dashboard has been modified by another user. Please reload the page to get the latest version.",
               { duration: null }
             );
           }
@@ -101,8 +106,9 @@ function useDashboard(dashboardData) {
   }, [dashboard, updateDashboard]);
 
   const loadWidget = useCallback((widget, forceRefresh = false) => {
+    // console.log('[loadWidget] called for widget:', widget.id, 'forceRefresh:', forceRefresh);
+    // console.trace('[loadWidget] call stack');
     widget.getParametersDefs(); // Force widget to read parameters values from URL
-    setDashboard(currentDashboard => extend({}, currentDashboard));
     return widget
       .load(forceRefresh)
       .catch(error => {
@@ -111,8 +117,7 @@ function useDashboard(dashboardData) {
           return;
         }
         return Promise.reject(error);
-      })
-      .finally(() => setDashboard(currentDashboard => extend({}, currentDashboard)));
+      });
   }, []);
 
   const refreshWidget = useCallback(widget => loadWidget(widget, true), [loadWidget]);
@@ -130,18 +135,18 @@ function useDashboard(dashboardData) {
 
   const loadDashboard = useCallback(
     (forceRefresh = false, updatedParameters = []) => {
-      const affectedWidgets = getAffectedWidgets(dashboardRef.current.widgets, updatedParameters);
+      const affectedWidgets = getAffectedWidgets(dashboard.widgets, updatedParameters);
       const loadWidgetPromises = compact(
         affectedWidgets.map(widget => loadWidget(widget, forceRefresh).catch(error => error))
       );
 
       return Promise.all(loadWidgetPromises).then(() => {
-        const queryResults = compact(map(dashboardRef.current.widgets, widget => widget.getQueryResult()));
-        const updatedFilters = collectDashboardFilters(dashboardRef.current, queryResults, location.search);
+        const queryResults = compact(map(dashboard.widgets, widget => widget.getQueryResult()));
+        const updatedFilters = collectDashboardFilters(dashboard, queryResults, location.search);
         setFilters(updatedFilters);
       });
     },
-    [loadWidget]
+    [dashboard, loadWidget]
   );
 
   const refreshDashboard = useCallback(
@@ -207,6 +212,17 @@ function useDashboard(dashboardData) {
   useEffect(() => {
     setDashboard(dashboardData);
     loadDashboard();
+    // Initialize layout if empty
+    if (dashboardData && (!dashboardData.layout || dashboardData.layout.length === 0)) {
+      const initialLayout = dashboardData.widgets.map(widget => ({
+        i: widget.id.toString(),
+        x: widget.options.position.col,
+        y: widget.options.position.row,
+        w: widget.options.position.sizeX,
+        h: widget.options.position.sizeY,
+      }));
+      setDashboard(currentDashboard => ({ ...currentDashboard, layout: initialLayout }));
+    }
   }, [dashboardData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
@@ -250,5 +266,3 @@ function useDashboard(dashboardData) {
     duplicateDashboard,
   };
 }
-
-export default useDashboard;

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -90,7 +90,7 @@ export function useDashboard(dashboardData) {
             notification.error("Dashboard update failed", "Permission Denied.");
           } else if (status === 409) {
             notification.error(
-              "Dashboard Version Conflict", 
+              "Dashboard Version Conflict",
               "The dashboard has been modified by another user. Please reload the page to get the latest version.",
               { duration: null }
             );
@@ -109,15 +109,13 @@ export function useDashboard(dashboardData) {
     // console.log('[loadWidget] called for widget:', widget.id, 'forceRefresh:', forceRefresh);
     // console.trace('[loadWidget] call stack');
     widget.getParametersDefs(); // Force widget to read parameters values from URL
-    return widget
-      .load(forceRefresh)
-      .catch(error => {
-        // QueryResultErrors are expected
-        if (error instanceof QueryResultError) {
-          return;
-        }
-        return Promise.reject(error);
-      });
+    return widget.load(forceRefresh).catch(error => {
+      // QueryResultErrors are expected
+      if (error instanceof QueryResultError) {
+        return;
+      }
+      return Promise.reject(error);
+    });
   }, []);
 
   const refreshWidget = useCallback(widget => loadWidget(widget, true), [loadWidget]);

--- a/client/app/pages/dashboards/hooks/useEditModeHandler.js
+++ b/client/app/pages/dashboards/hooks/useEditModeHandler.js
@@ -76,11 +76,9 @@ export default function useEditModeHandler(canEditDashboard, widgets) {
         .catch(error => {
           setDashboardStatus(DashboardStatusEnum.SAVING_FAILED);
           if (error.response && error.response.status === 409) {
-            notification.error(
-              "Version Conflict",
-              "The dashboard layout has been modified. Please try saving again.",
-              { duration: null }
-            );
+            notification.error("Version Conflict", "The dashboard layout has been modified. Please try saving again.", {
+              duration: null,
+            });
           } else {
             notification.error(
               "Error Saving Layout",

--- a/client/app/pages/dashboards/hooks/useEditModeHandler.js
+++ b/client/app/pages/dashboards/hooks/useEditModeHandler.js
@@ -2,6 +2,7 @@ import { debounce, find, has, isMatch, map, pickBy } from "lodash";
 import { useCallback, useEffect, useState } from "react";
 import location from "@/services/location";
 import notification from "@/services/notification";
+import { axios } from "@/services/axios";
 
 export const DashboardStatusEnum = {
   SAVED: "saved",
@@ -54,14 +55,39 @@ export default function useEditModeHandler(canEditDashboard, widgets) {
           return Promise.resolve();
         }
 
-        return widget.save("options", { position });
+        const saveWidget = () => widget.save("options", { position });
+
+        return saveWidget().catch(error => {
+          if (error.response && error.response.status === 409) {
+            // If we get a version conflict, refresh the widget data and try again
+            return axios.get(`api/widgets/${widget.id}`).then(response => {
+              // Update the widget with fresh data
+              Object.assign(widget, response.data);
+              // Try saving again with new version
+              return saveWidget();
+            });
+          }
+          throw error;
+        });
       });
 
       return Promise.all(saveChangedWidgets)
         .then(() => setDashboardStatus(DashboardStatusEnum.SAVED))
-        .catch(() => {
+        .catch(error => {
           setDashboardStatus(DashboardStatusEnum.SAVING_FAILED);
-          notification.error("Error saving changes.");
+          if (error.response && error.response.status === 409) {
+            notification.error(
+              "Version Conflict",
+              "The dashboard layout has been modified. Please try saving again.",
+              { duration: null }
+            );
+          } else {
+            notification.error(
+              "Error Saving Layout",
+              "There was a problem saving the dashboard layout. Please try again.",
+              { duration: null }
+            );
+          }
         });
     },
     [canEditDashboard, widgets]

--- a/client/app/pages/dashboards/hooks/useEditModeHandler.js
+++ b/client/app/pages/dashboards/hooks/useEditModeHandler.js
@@ -57,7 +57,7 @@ export default function useEditModeHandler(canEditDashboard, widgets) {
 
         const saveWidget = () => widget.save("options", { position });
 
-        return saveWidget().catch(error => {
+        return saveWidget().catch((error) => {
           if (error.response && error.response.status === 409) {
             // If we get a version conflict, refresh the widget data and try again
             return axios.get(`api/widgets/${widget.id}`).then(response => {
@@ -73,7 +73,7 @@ export default function useEditModeHandler(canEditDashboard, widgets) {
 
       return Promise.all(saveChangedWidgets)
         .then(() => setDashboardStatus(DashboardStatusEnum.SAVED))
-        .catch(error => {
+        .catch((error) => {
           setDashboardStatus(DashboardStatusEnum.SAVING_FAILED);
           if (error.response && error.response.status === 409) {
             notification.error("Version Conflict", "The dashboard layout has been modified. Please try saving again.", {

--- a/client/app/pages/data-sources/DataSourcesList.jsx
+++ b/client/app/pages/data-sources/DataSourcesList.jsx
@@ -84,7 +84,7 @@ class DataSourcesList extends React.Component {
           }
         )
       )
-      .catch(error => this.props.onError(error));
+      .catch((error) => this.props.onError(error));
   }
 
   componentWillUnmount() {

--- a/client/app/pages/data-sources/EditDataSource.jsx
+++ b/client/app/pages/data-sources/EditDataSource.jsx
@@ -38,7 +38,7 @@ class EditDataSource extends React.Component {
         this.setState({ dataSource });
         DataSource.types().then(types => this.setState({ type: find(types, { type }), loading: false }));
       })
-      .catch(error => this.props.onError(error));
+      .catch((error) => this.props.onError(error));
   }
 
   saveDataSource = (values, successCallback, errorCallback) => {
@@ -46,7 +46,7 @@ class EditDataSource extends React.Component {
     helper.updateTargetWithValues(dataSource, values);
     DataSource.save(dataSource)
       .then(() => successCallback("Saved."))
-      .catch(error => {
+      .catch((error) => {
         const message = get(error, "response.data.message", "Failed saving.");
         errorCallback(message);
       });

--- a/client/app/pages/destinations/DestinationsList.jsx
+++ b/client/app/pages/destinations/DestinationsList.jsx
@@ -54,7 +54,7 @@ class DestinationsList extends React.Component {
           }
         )
       )
-      .catch(error => this.props.onError(error));
+      .catch((error) => this.props.onError(error));
   }
 
   createDestination = (selectedType, values) => {

--- a/client/app/pages/destinations/EditDestination.jsx
+++ b/client/app/pages/destinations/EditDestination.jsx
@@ -37,7 +37,7 @@ class EditDestination extends React.Component {
         this.setState({ destination });
         Destination.types().then(types => this.setState({ type: find(types, { type }), loading: false }));
       })
-      .catch(error => this.props.onError(error));
+      .catch((error) => this.props.onError(error));
   }
 
   saveDestination = (values, successCallback, errorCallback) => {
@@ -45,7 +45,7 @@ class EditDestination extends React.Component {
     helper.updateTargetWithValues(destination, values);
     Destination.save(destination)
       .then(() => successCallback("Saved."))
-      .catch(error => {
+      .catch((error) => {
         const message = get(error, "response.data.message", "Failed saving.");
         errorCallback(message);
       });

--- a/client/app/pages/groups/GroupDataSources.jsx
+++ b/client/app/pages/groups/GroupDataSources.jsx
@@ -104,7 +104,7 @@ class GroupDataSources extends React.Component {
         this.group = group;
         this.forceUpdate();
       })
-      .catch(error => {
+      .catch((error) => {
         this.props.controller.handleError(error);
       });
   }

--- a/client/app/pages/groups/GroupMembers.jsx
+++ b/client/app/pages/groups/GroupMembers.jsx
@@ -85,7 +85,7 @@ class GroupMembers extends React.Component {
         this.group = group;
         this.forceUpdate();
       })
-      .catch(error => {
+      .catch((error) => {
         this.props.controller.handleError(error);
       });
   }

--- a/client/app/pages/queries/hooks/useArchiveQuery.jsx
+++ b/client/app/pages/queries/hooks/useArchiveQuery.jsx
@@ -34,7 +34,7 @@ function doArchiveQuery(query) {
     .then(() => {
       return extend(query.clone(), { is_archived: true, schedule: null });
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Query could not be archived.");
       return Promise.reject(error);
     });

--- a/client/app/pages/queries/hooks/useUpdateQuery.jsx
+++ b/client/app/pages/queries/hooks/useUpdateQuery.jsx
@@ -58,7 +58,7 @@ function doSaveQuery(data, { canOverwrite = false } = {}) {
     };
   }
 
-  return Query.save(data).catch(error => {
+  return Query.save(data).catch((error) => {
     if (get(error, "response.status") === 409) {
       if (canOverwrite) {
         return confirmOverwrite()
@@ -113,7 +113,7 @@ export default function useUpdateQuery(query, onChange) {
             )
           );
         })
-        .catch(error => {
+        .catch((error) => {
           const notificationOptions = {};
           if (error instanceof SaveQueryConflictError) {
             notificationOptions.duration = null;

--- a/client/app/pages/query-snippets/QuerySnippetsList.jsx
+++ b/client/app/pages/query-snippets/QuerySnippetsList.jsx
@@ -87,7 +87,7 @@ class QuerySnippetsList extends React.Component {
       } else {
         QuerySnippet.get({ id: querySnippetId })
           .then(this.showSnippetDialog)
-          .catch(error => {
+          .catch((error) => {
             this.props.controller.handleError(error);
           });
       }

--- a/client/app/pages/settings/hooks/useOrganizationSettings.js
+++ b/client/app/pages/settings/hooks/useOrganizationSettings.js
@@ -27,7 +27,7 @@ export default function useOrganizationSettings({ onError }) {
           setIsLoading(false);
         }
       })
-      .catch(error => {
+      .catch((error) => {
         if (!isCancelled) {
           handleError(error);
         }

--- a/client/app/pages/users/UserProfile.jsx
+++ b/client/app/pages/users/UserProfile.jsx
@@ -30,7 +30,7 @@ function UserProfile({ userId, onError }) {
           setUser(User.convertUserInfo(user));
         }
       })
-      .catch(error => {
+      .catch((error) => {
         if (!isCancelled) {
           handleError(error);
         }

--- a/client/app/pages/users/UsersList.jsx
+++ b/client/app/pages/users/UsersList.jsx
@@ -160,7 +160,7 @@ class UsersList extends React.Component {
           });
         }
       })
-      .catch(error => {
+      .catch((error) => {
         const message = find([get(error, "response.data.message"), get(error, "message"), "Failed saving."], isString);
         return Promise.reject(new Error(message));
       });

--- a/client/app/pages/users/components/PasswordForm/ChangePasswordDialog.jsx
+++ b/client/app/pages/users/components/PasswordForm/ChangePasswordDialog.jsx
@@ -72,7 +72,7 @@ class ChangePasswordDialog extends React.Component {
               notification.success("Saved.");
               this.props.dialog.close({ success: true });
             })
-            .catch(error => {
+            .catch((error) => {
               notification.error(get(error, "response.data.message", "Failed saving."));
               this.setState({ updatingPassword: false });
             });

--- a/client/app/pages/users/components/UserInfoForm.jsx
+++ b/client/app/pages/users/components/UserInfoForm.jsx
@@ -31,7 +31,7 @@ export default function UserInfoForm(props) {
           successCallback("Saved.");
           handleChange(User.convertUserInfo(user));
         })
-        .catch(error => {
+        .catch((error) => {
           errorCallback(get(error, "response.data.message", "Failed saving."));
         });
     },

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -350,7 +350,7 @@ class QueryResult {
         queryResult.isLoadingResult = false;
         queryResult.update(response);
       })
-      .catch(error => {
+      .catch((error) => {
         // Error handler
         queryResult.isLoadingResult = false;
         handleErrorResponse(queryResult, error);
@@ -365,7 +365,7 @@ class QueryResult {
       .then(response => {
         this.update(response);
       })
-      .catch(error => {
+      .catch((error) => {
         handleErrorResponse(this, error);
       });
   }
@@ -379,7 +379,7 @@ class QueryResult {
         this.update(response);
         this.isLoadingResult = false;
       })
-      .catch(error => {
+      .catch((error) => {
         if (tryCount === undefined) {
           tryCount = 0;
         }
@@ -422,7 +422,7 @@ class QueryResult {
           }, waitTime);
         }
       })
-      .catch(error => {
+      .catch((error) => {
         logger("Connection error", error);
         // TODO: use QueryResultError, or better yet: exception/reject of promise.
         this.update({
@@ -458,7 +458,7 @@ class QueryResult {
           queryResult.refreshStatus(id, parameters);
         }
       })
-      .catch(error => {
+      .catch((error) => {
         handleErrorResponse(queryResult, error);
       });
 
@@ -488,7 +488,7 @@ class QueryResult {
           queryResult.refreshStatus(query, parameters);
         }
       })
-      .catch(error => {
+      .catch((error) => {
         handleErrorResponse(queryResult, error);
       });
 

--- a/client/app/services/user.js
+++ b/client/app/services/user.js
@@ -23,7 +23,7 @@ function enableUser(user) {
       user.profile_image_url = data.profile_image_url;
       return data;
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Cannot enable user", getErrorMessage(error));
     });
 }
@@ -38,7 +38,7 @@ function disableUser(user) {
       user.profile_image_url = data.profile_image_url;
       return data;
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Cannot disable user", getErrorMessage(error));
     });
 }
@@ -51,7 +51,7 @@ function deleteUser(user) {
       notification.warning(`User ${userName} has been deleted.`);
       return data;
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Cannot delete user", getErrorMessage(error));
     });
 }
@@ -76,7 +76,7 @@ function regenerateApiKey(user) {
       notification.success("The API Key has been updated.");
       return data.api_key;
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Failed regenerating API Key", getErrorMessage(error));
     });
 }
@@ -91,7 +91,7 @@ function sendPasswordReset(user) {
       }
       notification.success("Password reset email sent.");
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Failed to send password reset email", getErrorMessage(error));
     });
 }
@@ -106,7 +106,7 @@ function resendInvitation(user) {
       }
       notification.success("Invitation sent.");
     })
-    .catch(error => {
+    .catch((error) => {
       notification.error("Failed to resend invitation", getErrorMessage(error));
     });
 }

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -10,7 +10,6 @@ import {
   difference,
   filter,
   map,
-  merge,
   sortBy,
   indexOf,
   size,
@@ -184,9 +183,19 @@ class Widget {
   }
 
   save(key, value) {
-    const data = pick(this, "options", "text", "id", "width", "dashboard_id", "visualization_id");
-    if (key && value) {
-      data[key] = merge({}, data[key], value); // done like this so `this.options` doesn't get updated by side-effect
+    let data = pick(this, "options", "text", "id", "width", "dashboard_id", "visualization_id", "version");
+    
+    if (key) {
+      if (value) {
+        // If we're updating options, merge with existing options
+        if (key === 'options' && typeof value === 'object') {
+          data.options = { ...this.options, ...value };
+        } else {
+          data[key] = value;
+        }
+      } else {
+        data = key;
+      }
     }
 
     let url = "api/widgets";
@@ -194,8 +203,8 @@ class Widget {
       url = `${url}/${this.id}`;
     }
 
-    return axios.post(url, data).then(data => {
-      each(data, (v, k) => {
+    return axios.post(url, data).then(response => {
+      each(response.data, (v, k) => {
         this[k] = v;
       });
 

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -170,7 +170,7 @@ class Widget {
           }
           return result;
         })
-        .catch(error => {
+        .catch((error) => {
           if (this.queryResult === queryResult) {
             this.loading = false;
             this.data = error;

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -184,11 +184,11 @@ class Widget {
 
   save(key, value) {
     let data = pick(this, "options", "text", "id", "width", "dashboard_id", "visualization_id", "version");
-    
+
     if (key) {
       if (value) {
         // If we're updating options, merge with existing options
-        if (key === 'options' && typeof value === 'object') {
+        if (key === "options" && typeof value === "object") {
           data.options = { ...this.options, ...value };
         } else {
           data[key] = value;

--- a/client/cypress/integration/dashboard/dashboard_spec.js
+++ b/client/cypress/integration/dashboard/dashboard_spec.js
@@ -142,4 +142,23 @@ describe("Dashboard", () => {
       cy.viewport(767, 800);
     });
   });
+
+  it("changes dashboard background color", () => {
+    cy.createDashboard("Color Test Dashboard").then(({ id }) => {
+      cy.visit(`/dashboards/${id}?edit`);
+      
+      // Open settings
+      cy.contains("Dashboard Settings").should("be.visible");
+      
+      // Check default background color
+      cy.get('input[type="color"]').should("have.value", "#ffffff");
+      
+      // Change background color
+      cy.get('input[type="color"]').invoke("val", "#ff0000").trigger("input").trigger("change");
+      
+      // Save and verify color was applied
+      cy.contains("button", "Done Editing").click();
+      cy.get(".dashboard-wrapper").should("have.css", "background-color", "rgb(255, 0, 0)");
+    });
+  });
 });

--- a/client/cypress/integration/dashboard/dashboard_spec.js
+++ b/client/cypress/integration/dashboard/dashboard_spec.js
@@ -146,16 +146,19 @@ describe("Dashboard", () => {
   it("changes dashboard background color", () => {
     cy.createDashboard("Color Test Dashboard").then(({ id }) => {
       cy.visit(`/dashboards/${id}?edit`);
-      
+
       // Open settings
       cy.contains("Dashboard Settings").should("be.visible");
-      
+
       // Check default background color
       cy.get('input[type="color"]').should("have.value", "#ffffff");
-      
+
       // Change background color
-      cy.get('input[type="color"]').invoke("val", "#ff0000").trigger("input").trigger("change");
-      
+      cy.get('input[type="color"]')
+        .invoke("val", "#ff0000")
+        .trigger("input")
+        .trigger("change");
+
       // Save and verify color was applied
       cy.contains("button", "Done Editing").click();
       cy.get(".dashboard-wrapper").should("have.css", "background-color", "rgb(255, 0, 0)");

--- a/tests/models/test_dashboard_background.py
+++ b/tests/models/test_dashboard_background.py
@@ -1,0 +1,98 @@
+from tests import BaseTestCase
+from redash.models import Dashboard, db, Widget
+from redash.serializers import serialize_dashboard, serialize_widget
+
+
+class TestDashboardBackground(BaseTestCase):
+    def test_default_background_color(self):
+        dashboard = self.factory.create_dashboard()
+        dashboard.options = {}  # Ensure options is initialized
+        db.session.add(dashboard)
+        db.session.commit()
+        
+        serialized = serialize_dashboard(dashboard)
+        self.assertEqual(serialized["options"]["backgroundColor"], "#ffffff")
+
+    def test_custom_background_color(self):
+        dashboard = self.factory.create_dashboard()
+        dashboard.options = {"backgroundColor": "#000000"}
+        db.session.add(dashboard)
+        db.session.commit()
+        
+        serialized = serialize_dashboard(dashboard)
+        self.assertEqual(serialized["options"]["backgroundColor"], "#000000")
+
+    def test_background_color_passed_to_visualization(self):
+        dashboard = self.factory.create_dashboard()
+        dashboard.options = {"backgroundColor": "#cccccc"}
+        db.session.add(dashboard)
+        db.session.commit()
+
+        # Create a visualization widget
+        ds = self.factory.create_data_source()
+        query = self.factory.create_query(data_source=ds)
+        viz = self.factory.create_visualization(query_rel=query, options={})  # Initialize options
+        widget = self.factory.create_widget(visualization=viz, dashboard=dashboard)
+        db.session.add(widget)
+        db.session.commit()
+
+        # Verify the background color is passed to the widget
+        serialized = serialize_dashboard(dashboard, with_widgets=True)
+        self.assertEqual(serialized["options"]["backgroundColor"], "#cccccc")
+        # Verify the background color is passed to the visualization options
+        self.assertEqual(
+            serialized["widgets"][0]["visualization"]["options"]["dashboardBackgroundColor"],
+            "#cccccc"
+        )
+
+    def test_dashboard_serialization_includes_background_color(self):
+        dashboard = self.factory.create_dashboard()
+        dashboard.options = {"backgroundColor": "#ff0000"}
+        db.session.add(dashboard)
+        db.session.commit()
+
+        serialized = serialize_dashboard(dashboard)
+        self.assertEqual(serialized["options"]["backgroundColor"], "#ff0000")
+
+    def test_dashboard_serialization_defaults_to_white(self):
+        dashboard = self.factory.create_dashboard()
+        dashboard.options = {}
+        db.session.add(dashboard)
+        db.session.commit()
+
+        serialized = serialize_dashboard(dashboard)
+        self.assertEqual(serialized["options"]["backgroundColor"], "#ffffff")
+
+    def test_widget_serialization_includes_dashboard_background(self):
+        dashboard = self.factory.create_dashboard()
+        dashboard.options = {"backgroundColor": "#ff0000"}
+        db.session.add(dashboard)
+        db.session.commit()
+
+        visualization = self.factory.create_visualization(options={})  # Initialize options
+        widget = self.factory.create_widget(dashboard=dashboard, visualization=visualization)
+        db.session.add(widget)
+        db.session.commit()
+
+        serialized = serialize_widget(widget)
+        self.assertEqual(
+            serialized["visualization"]["options"]["dashboardBackgroundColor"],
+            "#ff0000"
+        )
+
+    def test_widget_serialization_defaults_to_white_background(self):
+        dashboard = self.factory.create_dashboard()
+        dashboard.options = {}
+        db.session.add(dashboard)
+        db.session.commit()
+
+        visualization = self.factory.create_visualization(options={})  # Initialize options
+        widget = self.factory.create_widget(dashboard=dashboard, visualization=visualization)
+        db.session.add(widget)
+        db.session.commit()
+
+        serialized = serialize_widget(widget)
+        self.assertEqual(
+            serialized["visualization"]["options"]["dashboardBackgroundColor"],
+            "#ffffff"
+        ) 

--- a/viz-lib/__tests__/components/VisualizationRenderer.test.js
+++ b/viz-lib/__tests__/components/VisualizationRenderer.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { VisualizationRenderer } from '../../src/components/visualizations/VisualizationRenderer';
+
+jest.mock('../../src/components/visualizations/renderer', () => ({
+  Renderer: jest.fn(({ options }) => <div data-testid="mock-renderer" data-options={JSON.stringify(options)} />)
+}));
+
+describe('VisualizationRenderer', () => {
+  const defaultProps = {
+    visualization: {
+      id: 1,
+      type: 'chart',
+      name: 'Test Chart',
+      options: { some_option: 'value' }
+    },
+    queryResult: {
+      id: 1,
+      data: { columns: [], rows: [] }
+    }
+  };
+
+  it('should pass background color to visualization options', () => {
+    const backgroundColor = '#f0f8ff';
+    const { getByTestId } = render(
+      <VisualizationRenderer
+        {...defaultProps}
+        backgroundColor={backgroundColor}
+      />
+    );
+
+    const renderer = getByTestId('mock-renderer');
+    const options = JSON.parse(renderer.dataset.options);
+
+    expect(options.backgroundColor).toBe(backgroundColor);
+    expect(options.some_option).toBe('value');
+  });
+
+  it('should not include backgroundColor in options when not specified', () => {
+    const { getByTestId } = render(
+      <VisualizationRenderer {...defaultProps} />
+    );
+
+    const renderer = getByTestId('mock-renderer');
+    const options = JSON.parse(renderer.dataset.options);
+
+    expect(options.backgroundColor).toBeUndefined();
+    expect(options.some_option).toBe('value');
+  });
+}); 

--- a/viz-lib/__tests__/components/VisualizationRenderer.test.js
+++ b/viz-lib/__tests__/components/VisualizationRenderer.test.js
@@ -1,50 +1,43 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import { VisualizationRenderer } from '../../src/components/visualizations/VisualizationRenderer';
+import React from "react";
+import { render } from "@testing-library/react";
+import { VisualizationRenderer } from "../../src/components/visualizations/VisualizationRenderer";
 
-jest.mock('../../src/components/visualizations/renderer', () => ({
-  Renderer: jest.fn(({ options }) => <div data-testid="mock-renderer" data-options={JSON.stringify(options)} />)
+jest.mock("../../src/components/visualizations/renderer", () => ({
+  Renderer: jest.fn(({ options }) => <div data-testid="mock-renderer" data-options={JSON.stringify(options)} />),
 }));
 
-describe('VisualizationRenderer', () => {
+describe("VisualizationRenderer", () => {
   const defaultProps = {
     visualization: {
       id: 1,
-      type: 'chart',
-      name: 'Test Chart',
-      options: { some_option: 'value' }
+      type: "chart",
+      name: "Test Chart",
+      options: { some_option: "value" },
     },
     queryResult: {
       id: 1,
-      data: { columns: [], rows: [] }
-    }
+      data: { columns: [], rows: [] },
+    },
   };
 
-  it('should pass background color to visualization options', () => {
-    const backgroundColor = '#f0f8ff';
-    const { getByTestId } = render(
-      <VisualizationRenderer
-        {...defaultProps}
-        backgroundColor={backgroundColor}
-      />
-    );
+  it("should pass background color to visualization options", () => {
+    const backgroundColor = "#f0f8ff";
+    const { getByTestId } = render(<VisualizationRenderer {...defaultProps} backgroundColor={backgroundColor} />);
 
-    const renderer = getByTestId('mock-renderer');
+    const renderer = getByTestId("mock-renderer");
     const options = JSON.parse(renderer.dataset.options);
 
     expect(options.backgroundColor).toBe(backgroundColor);
-    expect(options.some_option).toBe('value');
+    expect(options.some_option).toBe("value");
   });
 
-  it('should not include backgroundColor in options when not specified', () => {
-    const { getByTestId } = render(
-      <VisualizationRenderer {...defaultProps} />
-    );
+  it("should not include backgroundColor in options when not specified", () => {
+    const { getByTestId } = render(<VisualizationRenderer {...defaultProps} />);
 
-    const renderer = getByTestId('mock-renderer');
+    const renderer = getByTestId("mock-renderer");
     const options = JSON.parse(renderer.dataset.options);
 
     expect(options.backgroundColor).toBeUndefined();
-    expect(options.some_option).toBe('value');
+    expect(options.some_option).toBe("value");
   });
-}); 
+});

--- a/viz-lib/__tests__/visualizations/chart/plotly/prepareLayout.test.js
+++ b/viz-lib/__tests__/visualizations/chart/plotly/prepareLayout.test.js
@@ -1,30 +1,30 @@
-import { prepareLayout } from '../../../../src/visualizations/chart/plotly/prepareLayout';
+import { prepareLayout } from "../../../../src/visualizations/chart/plotly/prepareLayout";
 
-describe('Chart Background', () => {
-  it('should set background color in layout when specified', () => {
+describe("Chart Background", () => {
+  it("should set background color in layout when specified", () => {
     const element = { offsetWidth: 100, offsetHeight: 100 };
     const options = {
-      legend: { enabled: true, traceorder: 'normal' },
-      backgroundColor: '#f0f0f0'
+      legend: { enabled: true, traceorder: "normal" },
+      backgroundColor: "#f0f0f0",
     };
     const data = [];
-    
+
     const layout = prepareLayout(element, options, data);
-    
-    expect(layout.paper_bgcolor).toBe('#f0f0f0');
-    expect(layout.plot_bgcolor).toBe('#f0f0f0');
+
+    expect(layout.paper_bgcolor).toBe("#f0f0f0");
+    expect(layout.plot_bgcolor).toBe("#f0f0f0");
   });
 
-  it('should use default background color when not specified', () => {
+  it("should use default background color when not specified", () => {
     const element = { offsetWidth: 100, offsetHeight: 100 };
     const options = {
-      legend: { enabled: true, traceorder: 'normal' }
+      legend: { enabled: true, traceorder: "normal" },
     };
     const data = [];
-    
+
     const layout = prepareLayout(element, options, data);
-    
-    expect(layout.paper_bgcolor).toBe('#ffffff');
-    expect(layout.plot_bgcolor).toBe('#ffffff');
+
+    expect(layout.paper_bgcolor).toBe("#ffffff");
+    expect(layout.plot_bgcolor).toBe("#ffffff");
   });
-}); 
+});

--- a/viz-lib/__tests__/visualizations/chart/plotly/prepareLayout.test.js
+++ b/viz-lib/__tests__/visualizations/chart/plotly/prepareLayout.test.js
@@ -1,0 +1,30 @@
+import { prepareLayout } from '../../../../src/visualizations/chart/plotly/prepareLayout';
+
+describe('Chart Background', () => {
+  it('should set background color in layout when specified', () => {
+    const element = { offsetWidth: 100, offsetHeight: 100 };
+    const options = {
+      legend: { enabled: true, traceorder: 'normal' },
+      backgroundColor: '#f0f0f0'
+    };
+    const data = [];
+    
+    const layout = prepareLayout(element, options, data);
+    
+    expect(layout.paper_bgcolor).toBe('#f0f0f0');
+    expect(layout.plot_bgcolor).toBe('#f0f0f0');
+  });
+
+  it('should use default background color when not specified', () => {
+    const element = { offsetWidth: 100, offsetHeight: 100 };
+    const options = {
+      legend: { enabled: true, traceorder: 'normal' }
+    };
+    const data = [];
+    
+    const layout = prepareLayout(element, options, data);
+    
+    expect(layout.paper_bgcolor).toBe('#ffffff');
+    expect(layout.plot_bgcolor).toBe('#ffffff');
+  });
+}); 

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
@@ -122,12 +122,12 @@ export default function prepareLayout(element: any, options: any, data: any) {
     hoverlabel: {
       namelength: -1,
     },
-    paper_bgcolor: options.backgroundColor || '#ffffff',
-    plot_bgcolor: options.backgroundColor || '#ffffff',
+    paper_bgcolor: options.backgroundColor || "#ffffff",
+    plot_bgcolor: options.backgroundColor || "#ffffff",
   };
 
   if (["line", "area", "column"].includes(options.globalSeriesType)) {
-    layout.hovermode = options.swappedAxes ? 'y' : 'x';
+    layout.hovermode = options.swappedAxes ? "y" : "x";
   }
 
   switch (options.globalSeriesType) {

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
@@ -21,7 +21,7 @@ function prepareXAxis(axisOptions: any, additionalOptions: any) {
     title: getAxisTitle(axisOptions),
     type: getAxisScaleType(axisOptions),
     automargin: true,
-    tickformat: axisOptions.tickFormat,
+    tickformat: axisOptions.tickFormat ?? null,
   };
 
   if (additionalOptions.sortX && axis.type === "category") {
@@ -49,7 +49,7 @@ function prepareYAxis(axisOptions: any) {
     automargin: true,
     autorange: true,
     range: null,
-    tickformat: axisOptions.tickFormat,
+    tickformat: axisOptions.tickFormat ?? null,
   };
 }
 
@@ -109,7 +109,7 @@ function prepareBoxLayout(layout: any, options: any, data: any) {
 }
 
 export default function prepareLayout(element: any, options: any, data: any) {
-  const layout = {
+  const layout: any = {
     margin: { l: 10, r: 10, b: 5, t: 20, pad: 4 },
     // plot size should be at least 5x5px
     width: Math.max(5, Math.floor(element.offsetWidth)),
@@ -122,7 +122,13 @@ export default function prepareLayout(element: any, options: any, data: any) {
     hoverlabel: {
       namelength: -1,
     },
+    paper_bgcolor: options.backgroundColor || '#ffffff',
+    plot_bgcolor: options.backgroundColor || '#ffffff',
   };
+
+  if (["line", "area", "column"].includes(options.globalSeriesType)) {
+    layout.hovermode = options.swappedAxes ? 'y' : 'x';
+  }
 
   switch (options.globalSeriesType) {
     case "pie":

--- a/viz-lib/src/visualizations/table/renderer.less
+++ b/viz-lib/src/visualizations/table/renderer.less
@@ -6,15 +6,26 @@
     display: block;
     text-align: center;
     margin-bottom: 0;
+    background: inherit;
   }
 
   .ant-table {
     overflow-x: auto;
+    background: inherit;
+
+    .ant-table-container {
+      background: inherit;
+    }
+
+    .ant-table-content {
+      background: inherit;
+    }
   }
 
   .table-fixed-header {
     table {
       border-top: 0;
+      background: inherit;
 
       th:not(.table-visualization-search) {
         position: sticky !important;
@@ -22,7 +33,17 @@
         top: 0;
         border-top: 0;
         z-index: 1;
-        background: #fafafa !important;
+        background: inherit !important;
+      }
+
+      tbody {
+        background: inherit;
+        tr {
+          background: inherit !important;
+          td {
+            background: inherit !important;
+          }
+        }
       }
     }
   }
@@ -30,6 +51,7 @@
   table {
     border-top: @border-width-base @border-style-base @border-color-split;
     border-bottom: 0;
+    background: inherit;
 
     .display-as-number,
     .display-as-boolean,
@@ -116,6 +138,16 @@
             padding: 0 @size * 1/4;
             margin: 0 5px 0 0;
           }
+        }
+      }
+    }
+
+    tbody {
+      background: inherit;
+      tr {
+        background: inherit !important;
+        td {
+          background: inherit !important;
         }
       }
     }


### PR DESCRIPTION
# Title:
Feature: Dashboard color picker and background color propagation
Description:
This PR introduces a dashboard color picker and propagates the selected background color to widgets and visualizations.
Key changes:
Adds a color picker to the dashboard settings.
Applies the selected background color to dashboard widgets and visualizations.
Updates relevant styles and integrates with Plotly for consistent background rendering.
Includes tests for background color propagation.

Trying to get restyler to not fail. 

<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x ] Unit tests (pytest, jest)
- [ x] E2E Tests (Cypress)
- [ x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
