### PR TITLE
cypress: skip dashboard sharing

### DIFF
--- a/client/cypress/integration/dashboard/sharing_spec.js
+++ b/client/cypress/integration/dashboard/sharing_spec.js
@@ -156,12 +156,7 @@ describe("Dashboard Sharing", () => {
             cy.title().should("eq", "Login to Redash"); // Make sure it's logged out
             cy.visit(secretAddress);
             cy.getByTestId("TableVisualization", { timeout: 10000 }).should("exist");
-            cy.contains(
-              ".alert",
-              "This query contains potentially unsafe parameters" +
-                " and cannot be executed on a shared dashboard or an embedded visualization."
-            );
-            cy.percySnapshot("Successfully Shared Parameterized Dashboard With Some Unsafe Queries");
+            // no assertion since the API is patched to allow this
           });
         });
     });


### PR DESCRIPTION
## What type of PR is this? 

- [x] other

## Description

Skip assertion since the API is patched to allow sharing a dashboard with text parameters

## How is this tested?

- [x] E2E Tests (Cypress)