### PR TITLE
Run CI workflow on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,5 @@
 name: Tests
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: pull_request
 env:
   NODE_VERSION: 18
   YARN_VERSION: 1.22.22


### PR DESCRIPTION
## Description

Upstream Redash only runs pull requests against `master`, but we maintain branches such as `v24.11.0`